### PR TITLE
Changes that were required for additional build machines

### DIFF
--- a/build_from_source/packages/ccache
+++ b/build_from_source/packages/ccache
@@ -35,7 +35,7 @@ set              BASE_PATH        $PACKAGES_DIR
 prepend-path     PATH               \$BASE_PATH/ccache/bin
 prepend-path     MANPATH            \$BASE_PATH/ccache/share/man
 
-if {[is-loaded moose/.clang]} {
+if {[is-loaded moose/.clang_3.7.0] || [is-loaded clang]} {
   setenv           CC                 "ccache clang"
   setenv           CXX                "ccache clang++"
 } else {

--- a/build_from_source/packages/cppunit-clang
+++ b/build_from_source/packages/cppunit-clang
@@ -37,7 +37,7 @@ pre_run() {
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.cppunit-clang
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.cppunit-1.12.1-clang
 #%Module1.0#####################################################################
 ##
 ## CPPUnit Clang 
@@ -55,7 +55,7 @@ prepend-path INCLUDE                     \$CPPUNIT_PATH/include
 prepend-path PATH                        \$CPPUNIT_PATH/bin
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/adv_modules
-    ln -s ../modulefiles/moose/.cppunit-clang cppunit-clang
+    ln -s ../modulefiles/moose/.cppunit-1.12.1-clang cppunit-clang
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/cppunit-gcc
+++ b/build_from_source/packages/cppunit-gcc
@@ -37,7 +37,7 @@ pre_run() {
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.cppunit-gcc
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.cppunit-1.12.1-gcc
 #%Module1.0#####################################################################
 ##
 ## CPPUnit GCC
@@ -52,7 +52,7 @@ prepend-path INCLUDE           \$CPPUNIT_PATH/include
 prepend-path PATH              \$CPPUNIT_PATH/bin
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/adv_modules
-    ln -s ../modulefiles/moose/.cppunit-gcc cppunit-gcc
+    ln -s ../modulefiles/moose/.cppunit-1.12.1-gcc cppunit-gcc
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/llvm
+++ b/build_from_source/packages/llvm
@@ -44,7 +44,7 @@ pre_run() {
       module load gcc
       export CC=gcc; export CXX=g++
     fi
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.clang
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.clang_3.7.0
 #%Module1.0#####################################################################
 ##
 ## Clang 3.7.0 modulefile
@@ -71,7 +71,7 @@ EOF
 
 post_run() {
     cd $PACKAGES_DIR/Modules/3.2.10/adv_modules
-    ln -s ../modulefiles/moose/.clang clang
+    ln -s ../modulefiles/moose/.clang_3.7.0 clang
     if [ `uname` = "Darwin" ]; then
 	cat <<'EOF' > $PACKAGES_DIR/${PACKAGE}_3.7.0/lib/change_links.sh
 #!/bin/bash

--- a/build_from_source/packages/miniconda
+++ b/build_from_source/packages/miniconda
@@ -33,7 +33,7 @@ pre_run() {
     fi
     PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda update conda --yes
     if [ $? -ne 0 ]; then echo "Failed to update miniconda"; cleanup 1; fi
-    PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install coverage vtk pyyaml matplotlib pyside conda-build --yes
+    PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install coverage reportlab mako vtk pyyaml matplotlib pyside conda-build --yes
     if [ $? -ne 0 ]; then echo "Failed to install miniconda packages"; cleanup 1; fi
 }
 post_run() {

--- a/build_from_source/packages/modules
+++ b/build_from_source/packages/modules
@@ -94,8 +94,8 @@ if { [uname sysname] != "Darwin" } {
   module load moose/.mpich_petsc-3.6.4-clang
 } 
 module load moose/.vtk6-clang
-module load moose/.tbb
-module load moose/.cppunit-clang
+module load moose/.tbb44_20150728
+module load moose/.cppunit-1.12.1-clang
 
 # If MOOSE_DIR is set, help the user out by prepending the moose/python path
 if { [ info exists ::env(MOOSE_DIR) ] } {
@@ -121,8 +121,8 @@ if { [uname sysname] != "Darwin" } {
   module load moose/.mpich-3.1.4_gcc
   module load moose/.mpich_petsc-3.6.4-gcc
 }
-module load moose/.tbb
-module load moose/.cppunit-gcc
+module load moose/.tbb44_20150728
+module load moose/.cppunit-1.12.1-gcc
 
 
 # If MOOSE_DIR is set, help the user out by prepending the moose/python path

--- a/build_from_source/packages/mpich-clang
+++ b/build_from_source/packages/mpich-clang
@@ -34,7 +34,7 @@ post_run() {
 set BASE_PATH   $PACKAGES_DIR
 
 conflict moose/.mpich-3.1.4_gcc moose/.openmpi-1.8.4_clang moose/.openmpi-1.8.4_gcc mpich-3.1.4_gcc openmpi-1.8.4_clang openmpi-1.8.4_gcc
-module load moose/.clang
+module load moose/.clang_3.7.0
 
 set             MPI_PATH                    \$BASE_PATH/mpich/mpich-3.1.4/clang-opt
 if { [uname sysname] != "Darwin" } {
@@ -56,7 +56,7 @@ setenv          MPI_HOME                    \$MPI_PATH
 prepend-path    PATH                        \$MPI_PATH/bin
 
 EOF
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/mpich-3.1.4_clang
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/mpich-clang
 #%Module1.0#####################################################################
 ##
 ## MPICH Clang
@@ -66,7 +66,7 @@ set BASE_PATH   $PACKAGES_DIR
 conflict moose/.mpich-3.1.4_clang moose/.mpich-3.1.4_gcc moose/.openmpi-1.8.4_clang moose/.openmpi-1.8.4_gcc mpich-3.1.4_gcc openmpi-1.8.4_clang openmpi-1.8.4_gcc
 
 if { ! [ is-loaded clang ] } {
-  module load moose/.clang
+  module load moose/.clang_3.7.0
 }
 
 set             MPI_PATH                    \$BASE_PATH/mpich/mpich-3.1.4/clang-opt
@@ -90,7 +90,7 @@ prepend-path    PATH                        \$MPI_PATH/bin
 
 append-path     MODULEPATH                  \$BASE_PATH/Modules/3.2.10/mpich_clang
 EOF
-    module load advanced_modules mpich-3.1.4_clang
+    module load advanced_modules mpich-clang
     cd $MPI_HOME/lib
     for sfile in `find . -type f -name "*.la"`; do
 	if [ `grep -c 'src_temp_' $sfile` -ge 1 ]; then

--- a/build_from_source/packages/mpich-gcc
+++ b/build_from_source/packages/mpich-gcc
@@ -57,7 +57,7 @@ prepend-path    LIBRARY           \$BASE_PATH/tbb/lib
 prepend-path    CPATH             \$BASE_PATH/tbb/include
 
 EOF
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/mpich-3.1.4_gcc
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/mpich-gcc
 #%Module1.0#####################################################################
 ##
 ## MPICH GCC
@@ -93,7 +93,7 @@ prepend-path    CPATH             \$BASE_PATH/tbb/include
 
 append-path     MODULEPATH        \$BASE_PATH/Modules/3.2.10/mpich_gcc
 EOF
-    module load advanced_modules mpich-3.1.4_gcc
+    module load advanced_modules mpich-gcc
     cd $MPI_HOME/lib
     for sfile in `find . -type f -name "*.la"`; do
 	if [ `grep -c 'src_temp_' $sfile` -ge 1 ]; then

--- a/build_from_source/packages/openmpi-clang
+++ b/build_from_source/packages/openmpi-clang
@@ -36,7 +36,7 @@ post_run() {
 set BASE_PATH   $PACKAGES_DIR
 
 conflict moose/.mpich-3.1.4_clang moose/.mpich-3.1.4_gcc moose/.openmpi-1.8.4_gcc mpich-3.1.4_clang mpich-3.1.4_gcc openmpi-1.8.4_gcc
-module load moose/.clang
+module load moose/.clang_3.7.0
 
 set             MPI_PATH                      \$BASE_PATH/openmpi/openmpi-1.8.4/clang-opt
 
@@ -59,7 +59,7 @@ setenv          MPI_HOME                      \$MPI_PATH
 prepend-path    PATH                          \$MPI_PATH/bin
 
 EOF
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/openmpi-1.8.4_clang
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/openmpi-clang
 #%Module1.0#####################################################################
 ##
 ## OpenMPI Clang
@@ -69,7 +69,7 @@ set BASE_PATH   $PACKAGES_DIR
 conflict moose/.openmpi-1.8.4_clang moose/.mpich-3.1.4_clang moose/.mpich-3.1.4_gcc moose/.openmpi-1.8.4_gcc mpich-3.1.4_clang mpich-3.1.4_gcc openmpi-1.8.4_gcc
 
 if { ! [ is-loaded clang ] } {
-  module load moose/.clang
+  module load moose/.clang_3.7.0
 }
 
 set             MPI_PATH                      \$BASE_PATH/openmpi/openmpi-1.8.4/clang-opt
@@ -94,7 +94,7 @@ prepend-path    PATH                          \$MPI_PATH/bin
 
 append-path     MODULEPATH                    \$BASE_PATH/Modules/3.2.10/openmpi_clang
 EOF
-    module load advanced_modules openmpi-1.8.4_clang
+    module load advanced_modules openmpi-clang
     cd $MPI_HOME/lib
     for sfile in `find . -type f -name "*.la"`; do
 	if [ `grep -c 'src_temp_' $sfile` -ge 1 ]; then

--- a/build_from_source/packages/openmpi-gcc
+++ b/build_from_source/packages/openmpi-gcc
@@ -59,7 +59,7 @@ setenv          MPI_HOME          \$MPI_PATH
 prepend-path    PATH              \$MPI_PATH/bin
 
 EOF
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/openmpi-1.8.4_gcc
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/adv_modules/openmpi-gcc
 #%Module1.0#####################################################################
 ##
 ## OpenMPI GCC
@@ -94,7 +94,7 @@ prepend-path    PATH              \$MPI_PATH/bin
 
 append-path     MODULEPATH        \$BASE_PATH/Modules/3.2.10/openmpi_gcc
 EOF
-    module load advanced_modules openmpi-1.8.4_gcc
+    module load advanced_modules openmpi-gcc
     cd $MPI_HOME/lib
     for sfile in `find . -type f -name "*.la"`; do
 	if [ `grep -c 'src_temp_' $sfile` -ge 1 ]; then

--- a/build_from_source/packages/petsc-3.5.4-mpich-clang
+++ b/build_from_source/packages/petsc-3.5.4-mpich-clang
@@ -46,7 +46,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_clang
+    module load advanced_modules cmake mpich-clang
     cat <<'EOF' > clang_openmp.patch
 diff -ru a/config/BuildSystem/config/package.py b/config/BuildSystem/config/package.py
 --- a/config/BuildSystem/config/package.py  2015-05-23 10:57:09.000000000 -0600

--- a/build_from_source/packages/petsc-3.5.4-mpich-gcc
+++ b/build_from_source/packages/petsc-3.5.4-mpich-gcc
@@ -46,7 +46,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_gcc
+    module load advanced_modules cmake mpich-gcc
     cat <<'EOF' > gcc_openmp.patch
 diff -ru a/config/BuildSystem/config/package.py b/config/BuildSystem/config/package.py
 --- a/config/BuildSystem/config/package.py  2015-05-23 10:57:09.000000000 -0600

--- a/build_from_source/packages/petsc-3.5.4-openmpi-clang
+++ b/build_from_source/packages/petsc-3.5.4-openmpi-clang
@@ -46,7 +46,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_clang
+    module load advanced_modules cmake openmpi-clang
     cat <<'EOF' > clang_openmp.patch
 diff -ru a/config/BuildSystem/config/package.py b/config/BuildSystem/config/package.py
 --- a/config/BuildSystem/config/package.py  2015-05-23 10:57:09.000000000 -0600

--- a/build_from_source/packages/petsc-3.5.4-openmpi-gcc
+++ b/build_from_source/packages/petsc-3.5.4-openmpi-gcc
@@ -46,7 +46,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_gcc
+    module load advanced_modules cmake openmpi-gcc
     cat <<'EOF' > gcc_openmp.patch
 diff -ru a/config/BuildSystem/config/package.py b/config/BuildSystem/config/package.py
 --- a/config/BuildSystem/config/package.py  2015-05-23 10:57:09.000000000 -0600

--- a/build_from_source/packages/petsc-3.6.4-mpich-clang
+++ b/build_from_source/packages/petsc-3.6.4-mpich-clang
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_clang
+    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {

--- a/build_from_source/packages/petsc-3.6.4-mpich-clang-dbg
+++ b/build_from_source/packages/petsc-3.6.4-mpich-clang-dbg
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_clang
+    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {

--- a/build_from_source/packages/petsc-3.6.4-mpich-gcc
+++ b/build_from_source/packages/petsc-3.6.4-mpich-gcc
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_gcc
+    module load advanced_modules cmake mpich-gcc
 }
 
 post_run() {

--- a/build_from_source/packages/petsc-3.6.4-openmpi-clang
+++ b/build_from_source/packages/petsc-3.6.4-openmpi-clang
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_clang
+    module load advanced_modules cmake openmpi-clang
 }
 
 post_run() {

--- a/build_from_source/packages/petsc-3.6.4-openmpi-gcc
+++ b/build_from_source/packages/petsc-3.6.4-openmpi-gcc
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_gcc
+    module load advanced_modules cmake openmpi-gcc
 }
 
 post_run() {

--- a/build_from_source/packages/petsc-3.6.4-openmpi-gcc-dbg
+++ b/build_from_source/packages/petsc-3.6.4-openmpi-gcc-dbg
@@ -45,7 +45,7 @@ INSTALL='false'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_gcc
+    module load advanced_modules cmake openmpi-gcc
 }
 
 post_run() {

--- a/build_from_source/packages/tbb
+++ b/build_from_source/packages/tbb
@@ -31,7 +31,7 @@ post_run() {
     else
 	cp build/linux_*_release/*.so* $PACKAGES_DIR/tbb/lib
     fi
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.tbb
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.tbb44_20150728
 #%Module1.0#####################################################################
 ##
 ## TBB modulefile
@@ -53,7 +53,7 @@ if { [uname sysname] == "Darwin" } {
 }
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/adv_modules
-    ln -s ../modulefiles/moose/.tbb tbb
+    ln -s ../modulefiles/moose/.tbb44_20150728 tbb
     if [ `uname` = "Darwin" ]; then
 	cat <<'EOF' > $PACKAGES_DIR/${PACKAGE}/lib/change_links.sh
 #!/bin/bash

--- a/build_from_source/packages/trilinos-mpich-clang-dbg
+++ b/build_from_source/packages/trilinos-mpich-clang-dbg
@@ -13,8 +13,8 @@ ARCH=(Darwin)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/mpich-clang-dbg \
@@ -55,31 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_clang
+    module load advanced_modules cmake mpich-clang
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
-    cat <<EOF > clang.patch
-diff -u -r trilinos-11.14.3-Source.orig/packages/nox/src-lapack/NOX_LAPACK_Matrix.H trilinos-11.14.3-Source/packages/nox/src-lapack/NOX_LAPACK_Matrix.H
---- trilinos-11.14.3-Source.orig/packages/nox/src-lapack/NOX_LAPACK_Matrix.H    2015-04-17 13:05:04.000000000 -0600
-+++ trilinos-11.14.3-Source/packages/nox/src-lapack/NOX_LAPACK_Matrix.H 2015-10-09 15:35:37.000000000 -0600
-@@ -104,7 +104,7 @@
-         stream << operator()(i,j) << " ";
-       stream << "]" << std::endl;
-     }
--    return stream;
-+    return stream.good();
-       }
-
-       //! Returns the number of rows in the matrix
-EOF
-    patch -p1 < clang.patch
     mkdir clang-dbg; cd clang-dbg
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-clang-dbg
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-12.6.2-clang-dbg
 #%Module1.0#####################################################################
 ##
 ##  Trilinos MPICH Clang Debug Module 
@@ -95,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/mpich-clang-dbg
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/mpich_clang
-    ln -s ../modulefiles/moose/.mpich-trilinos-clang-dbg trilinos-dbg
+    ln -s ../modulefiles/moose/.mpich-trilinos-12.6.2-clang-dbg trilinos-dbg
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/trilinos-mpich-clang-opt
+++ b/build_from_source/packages/trilinos-mpich-clang-opt
@@ -13,8 +13,8 @@ ARCH=(Darwin)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/mpich-clang-opt \
@@ -55,31 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_clang
+    module load advanced_modules cmake mpich-clang
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
-    cat <<EOF > clang.patch
-diff -u -r trilinos-11.14.3-Source.orig/packages/nox/src-lapack/NOX_LAPACK_Matrix.H trilinos-11.14.3-Source/packages/nox/src-lapack/NOX_LAPACK_Matrix.H
---- trilinos-11.14.3-Source.orig/packages/nox/src-lapack/NOX_LAPACK_Matrix.H    2015-04-17 13:05:04.000000000 -0600
-+++ trilinos-11.14.3-Source/packages/nox/src-lapack/NOX_LAPACK_Matrix.H 2015-10-09 15:35:37.000000000 -0600
-@@ -104,7 +104,7 @@
-         stream << operator()(i,j) << " ";
-       stream << "]" << std::endl;
-     }
--    return stream;
-+    return stream.good();
-       }
-
-       //! Returns the number of rows in the matrix
-EOF
-    patch -p1 < clang.patch
     mkdir clang-opt; cd clang-opt
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-clang-opt
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-12.6.2-clang-opt
 #%Module1.0#####################################################################
 ##
 ##  Trilinos MPICH Clang Optimized Module 
@@ -95,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/mpich-clang-opt
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/mpich_clang
-    ln -s ../modulefiles/moose/.mpich-trilinos-clang-opt trilinos-opt
+    ln -s ../modulefiles/moose/.mpich-trilinos-12.6.2-clang-opt trilinos-opt
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/trilinos-mpich-gcc-dbg
+++ b/build_from_source/packages/trilinos-mpich-gcc-dbg
@@ -13,8 +13,8 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/mpich-gcc-dbg \
@@ -55,16 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_gcc
+    module load advanced_modules cmake mpich-gcc
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
     mkdir gcc-dbg; cd gcc-dbg
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-gcc-dbg
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-12.6.2-gcc-dbg
 #%Module1.0#####################################################################
 ##
 ##  Trilinos MPICH GCC Debug Module 
@@ -80,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/mpich-gcc-dbg
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/mpich_gcc
-    ln -s ../modulefiles/moose/.mpich-trilinos-gcc-dbg trilinos-dbg
+    ln -s ../modulefiles/moose/.mpich-trilinos-12.6.2-gcc-dbg trilinos-dbg
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/trilinos-mpich-gcc-opt
+++ b/build_from_source/packages/trilinos-mpich-gcc-opt
@@ -13,8 +13,8 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/mpich-gcc-opt \
@@ -55,16 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake mpich-3.1.4_gcc
+    module load advanced_modules cmake mpich-gcc
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
     mkdir gcc-opt; cd gcc-opt
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-gcc-opt
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.mpich-trilinos-12.6.2-gcc-opt
 #%Module1.0#####################################################################
 ##
 ##  Trilinos MPICH GCC Optimized Module 
@@ -80,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/mpich-gcc-opt
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/mpich_gcc
-    ln -s ../modulefiles/moose/.mpich-trilinos-gcc-opt trilinos-opt
+    ln -s ../modulefiles/moose/.mpich-trilinos-12.6.2-gcc-opt trilinos-opt
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/trilinos-openmpi-gcc-dbg
+++ b/build_from_source/packages/trilinos-openmpi-gcc-dbg
@@ -13,8 +13,8 @@ ARCH=(Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/openmpi-gcc-dbg \
@@ -55,16 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_gcc
+    module load advanced_modules cmake openmpi-gcc
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
     mkdir gcc-dbg; cd gcc-dbg
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.openmpi-trilinos-gcc-dbg
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.openmpi-trilinos-12.6.2-gcc-dbg
 #%Module1.0#####################################################################
 ##
 ##  Trilinos OpenMPI GCC Debug Module
@@ -80,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/openmpi-gcc-dbg
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/openmpi_gcc
-    ln -s ../modulefiles/moose/.openmpi-trilinos-gcc-dbg trilinos-dbg
+    ln -s ../modulefiles/moose/.openmpi-trilinos-12.6.2-gcc-dbg trilinos-dbg
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/trilinos-openmpi-gcc-opt
+++ b/build_from_source/packages/trilinos-openmpi-gcc-opt
@@ -13,8 +13,8 @@ ARCH=(Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/trilinos-11.14.3-Source.tar.gz'
-EXTRACT='trilinos-11.14.3-Source.tar.gz'
+DOWNLOAD='https://github.com/trilinos/Trilinos/archive/trilinos-release-12-6-2.tar.gz'
+EXTRACT='trilinos-release-12-6-2.tar.gz'
 CONFIGURE="
 cmake \
 -D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/trilinos/openmpi-gcc-opt \
@@ -55,16 +55,16 @@ INSTALL='true'
 pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/3.2.10/init/bash
-    module load advanced_modules cmake openmpi-1.8.4_gcc
+    module load advanced_modules cmake openmpi-gcc
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
-    git checkout 76502c937b4ec52b521b617f9cc399e98dc53f0d
+    git checkout b40e1cec6f00760efb1107161df5596f6486429f
     cd ../
     mkdir gcc-opt; cd gcc-opt
 }
 
 post_run() {
-    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.openmpi-trilinos-gcc-opt
+    cat <<EOF > $PACKAGES_DIR/Modules/3.2.10/modulefiles/moose/.openmpi-trilinos-12.6.2-gcc-opt
 #%Module1.0#####################################################################
 ##
 ##  Trilinos OpenMPI GCC Optimized Module
@@ -80,7 +80,7 @@ if { [uname sysname] != "Darwin" } {
 setenv       TRILINOS_DIR                \$BASE_PATH/trilinos/openmpi-gcc-opt
 EOF
     cd $PACKAGES_DIR/Modules/3.2.10/openmpi_gcc
-    ln -s ../modulefiles/moose/.openmpi-trilinos-gcc-opt trilinos-opt
+    ln -s ../modulefiles/moose/.openmpi-trilinos-12.6.2-gcc-opt trilinos-opt
 }
 ##
 ## End Specifics

--- a/build_from_source/packages/vtk-clang
+++ b/build_from_source/packages/vtk-clang
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='http://mooseframework.org/source_packages/VTK-6.3.0.3tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/VTK-6.3.0.tar.gz'
 EXTRACT='VTK-6.3.0.tar.gz'
 CONFIGURE="cmake ../VTK-6.3.0 -DCMAKE_INSTALL_PREFIX=$PACKAGES_DIR/vtk-6.3/clang-opt -DCMAKE_INSTALL_RPATH:STRING=$PACKAGES_DIR/vtk-6.3/clang-opt/lib -DCMAKE_INSTALL_RPATH_USE_LINK_PATH:BOOL=ON -DCMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/vtk-6.3/clang-opt/lib -DCMAKE_MACOSX_RPATH:BOOL=ON -DVTK_WRAP_PYTHON=ON -Wno-dev"
 BUILD='true'


### PR DESCRIPTION
modify the way versions are represented when using modules
update trilinos package
add reportlab and mako to miniconda so SQA documentation can happen
devise a way to handle incorrect OS identification
