### PR TITLE
Several modifications to make CentOS build and our HPC build machines

### DIFF
--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -31,7 +31,13 @@ extract() {
 	    cleanup 1
 	fi
     done
-    cd $(echo ${EXTRACT[0]} | sed -e 's/[^a-zA-z]/ /g' | cut -d\  -f1)*
+    cd $(tar -tzf ${EXTRACT[0]} | sed -e 's@/.*@@' | uniq)
+    if [ $? -ne 0 ]; then
+	echo -e 'Failed to determine which directory to `cd` into'
+	cleanup 1
+    else
+	echo -e 'Entered build directory: '`pwd`
+    fi
 }
 
 configure() {

--- a/build_from_source/make_all.py
+++ b/build_from_source/make_all.py
@@ -3,7 +3,7 @@ import os, sys, subprocess, argparse, time, datetime, re, shutil
 from tempfile import TemporaryFile
 
 # Pre-requirements that we are aware of that on some linux machines is not sometimes available by default:
-prereqs = ['bison', 'flex', 'git', 'curl', 'make', 'bc', 'patch', 'bzip2']
+prereqs = ['bison', 'flex', 'git', 'curl', 'make', 'bc', 'patch', 'bzip2', 'uniq']
 
 def startJobs(args):
   (master_list, previous_progress) = getList()

--- a/build_from_source/make_all.py
+++ b/build_from_source/make_all.py
@@ -3,7 +3,7 @@ import os, sys, subprocess, argparse, time, datetime, re, shutil
 from tempfile import TemporaryFile
 
 # Pre-requirements that we are aware of that on some linux machines is not sometimes available by default:
-prereqs = ['bison', 'flex', 'git', 'curl', 'make']
+prereqs = ['bison', 'flex', 'git', 'curl', 'make', 'bc', 'patch', 'bzip2']
 
 def startJobs(args):
   (master_list, previous_progress) = getList()

--- a/build_from_source/packages/miniconda
+++ b/build_from_source/packages/miniconda
@@ -33,7 +33,7 @@ pre_run() {
     fi
     PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda update conda --yes
     if [ $? -ne 0 ]; then echo "Failed to update miniconda"; cleanup 1; fi
-    PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install coverage reportlab mako vtk pyyaml matplotlib pyside conda-build --yes
+    PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk pyyaml matplotlib pyside conda-build --yes
     if [ $? -ne 0 ]; then echo "Failed to install miniconda packages"; cleanup 1; fi
 }
 post_run() {

--- a/build_from_source/packages/modules
+++ b/build_from_source/packages/modules
@@ -86,13 +86,8 @@ EOF
 ##
 ##
 conflict moose-dev-gcc
-if { [uname sysname] != "Darwin" } {
-  module load moose/.openmpi-1.8.4_clang
-  module load moose/.openmpi_petsc-3.6.4-clang
-} else {
-  module load moose/.mpich-3.1.4_clang
-  module load moose/.mpich_petsc-3.6.4-clang
-} 
+module load moose/.mpich-3.1.4_clang
+module load moose/.mpich_petsc-3.6.4-clang
 module load moose/.vtk6-clang
 module load moose/.tbb44_20150728
 module load moose/.cppunit-1.12.1-clang
@@ -114,16 +109,12 @@ EOF
 ##
 conflict moose-dev-clang
 if { [uname sysname] != "Darwin" } {
-  module load moose/.openmpi-1.8.4_gcc
-  module load moose/.openmpi_petsc-3.6.4-gcc
   module load moose/.vtk6-gcc
-} else {
-  module load moose/.mpich-3.1.4_gcc
-  module load moose/.mpich_petsc-3.6.4-gcc
 }
+module load moose/.mpich-3.1.4_gcc
+module load moose/.mpich_petsc-3.6.4-gcc
 module load moose/.tbb44_20150728
 module load moose/.cppunit-1.12.1-gcc
-
 
 # If MOOSE_DIR is set, help the user out by prepending the moose/python path
 if { [ info exists ::env(MOOSE_DIR) ] } {


### PR DESCRIPTION
I use bc during make_all.py and was not checking for it
centos really is barebones... adding `patch` to the list of dependencies make_all.py needs
adding additional python modules that other applications need in order to test properly (raven)
centos needs bzip2. Which is not installed by default
openmpi is causing issues on linux machines. Switch to mpich by default for now
