### PR TITLE
Fix Welcome page for OS X

### DIFF
--- a/create_redistributable/pkg/OSX/Welcome_Panel.html
+++ b/create_redistributable/pkg/OSX/Welcome_Panel.html
@@ -12,7 +12,7 @@
         <LI><A HREF="http://clang.llvm.org/"><LLVM></A></LI>
         <LI><A HREF="http://www.open-mpi.org/"><OPENMPI></A></LI>
         <LI><A HREF="https://www.mpich.org/"><MPICH></A></LI>
-        <LI><A HREF="http://www.mcs.anl.gov/petsc/"><PETSC_OLD>/<PETSC_NEW></A></LI>
+        <LI><A HREF="http://www.mcs.anl.gov/petsc/"><PETSC_DEFAULT>/<PETSC_ALT></A></LI>
         <LI><A HREF="https://trilinos.org/"><TRILINOS></A></LI>
         <LI><A HREF="https://github.com/ORNL-CEES/DataTransferKit.git">Data Transfer Kit</A></LI>
         <LI><A HREF="http://vtk.org/"><VTK></A></LI>


### PR DESCRIPTION
with the PETSC identifier changes, forgot to update the welcome page template to match
