### PR TITLE
Inform PETSc to use our compiled version of GCC's libraries

### DIFF
--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -31,13 +31,14 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -31,13 +31,14 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-mpich-gcc
+++ b/build_from_source/template/petsc-alt-mpich-gcc
@@ -31,13 +31,13 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -31,13 +31,14 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-openmpi-gcc
+++ b/build_from_source/template/petsc-alt-openmpi-gcc
@@ -31,13 +31,13 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -31,13 +31,13 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -30,13 +30,14 @@ CONFIGURE="./configure \
 --download-metis=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -30,13 +30,13 @@ CONFIGURE="./configure \
 --download-metis=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-mpich-clang
+++ b/build_from_source/template/petsc-default-mpich-clang
@@ -31,13 +31,14 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-mpich-gcc
+++ b/build_from_source/template/petsc-default-mpich-gcc
@@ -31,13 +31,13 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-openmpi-clang
+++ b/build_from_source/template/petsc-default-openmpi-clang
@@ -31,13 +31,14 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp' \
+--LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-openmpi-gcc
+++ b/build_from_source/template/petsc-default-openmpi-gcc
@@ -31,13 +31,13 @@ CONFIGURE="./configure \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
-CC=mpicc CXX=mpicxx FC=mpif90 F77=mpif77 F90=mpif90 \
-CFLAGS='-fPIC -fopenmp' \
-CXXFLAGS='-fPIC -fopenmp' \
-FFLAGS='-fPIC -fopenmp' \
-FCFLAGS='-fPIC -fopenmp' \
-F90FLAGS='-fPIC -fopenmp' \
-F77FLAGS='-fPIC -fopenmp'"
+--CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \
+--CFLAGS='-fPIC -fopenmp' \
+--CXXFLAGS='-fPIC -fopenmp' \
+--FFLAGS='-fPIC -fopenmp' \
+--FCFLAGS='-fPIC -fopenmp' \
+--F90FLAGS='-fPIC -fopenmp' \
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'


### PR DESCRIPTION
Found that when linking fortran to C bindings, PETSc was defaulting to the system version of GCC, rather than the one we were building _only_ when using the Clang compiler.

GCC modifications not necessary for GCC targets, only Clang.
