### PR TITLE
Modify the way PETSc Clang is built

### DIFF
--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -37,8 +37,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -37,8 +37,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -37,8 +37,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -36,8 +36,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-mpich-clang
+++ b/build_from_source/template/petsc-default-mpich-clang
@@ -37,8 +37,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'

--- a/build_from_source/template/petsc-default-openmpi-clang
+++ b/build_from_source/template/petsc-default-openmpi-clang
@@ -37,8 +37,7 @@ CONFIGURE="./configure \
 --FFLAGS='-fPIC -fopenmp' \
 --FCFLAGS='-fPIC -fopenmp' \
 --F90FLAGS='-fPIC -fopenmp' \
---F77FLAGS='-fPIC -fopenmp' \
---LDFLAGS='-L$PACKAGES_DIR/<GCC>/lib64'"
+--F77FLAGS='-fPIC -fopenmp'"
 
 BUILD='false'
 INSTALL='false'


### PR DESCRIPTION
remove the LDFLAGS, as we beleive this is breaking moose modules
