### PR TITLE
Use system blas libraries while on Darwin machines

### DIFF
--- a/build_from_source/template/llvm
+++ b/build_from_source/template/llvm
@@ -119,7 +119,7 @@ post_run() {
     if [ `uname` = "Darwin" ]; then
 	# Because DYLD_LIBRARY_PATH no longer exists, we have to modify
 	# rpaths in all the llvm libraries to be absolute paths
-	cat <<'EOF' > $PACKAGES_DIR/<LLVM>/lib/change_links.sh
+	cat <<'EOF' > $PACKAGES_DIR/llvm-<LLVM>/lib/change_links.sh
 #!/bin/bash
 for sfile in `ls | grep dylib`; do
   if ! [ -L $sfile ]; then
@@ -140,11 +140,11 @@ for sfile in `ls | grep dylib`; do
   fi
 done
 EOF
-	  cd $PACKAGES_DIR/<LLVM>/lib/
+	  cd $PACKAGES_DIR/llvm-<LLVM>/lib/
 	  sh change_links.sh
 	  rm -f change_links.sh
     fi
-    cp -R $1/llvm/tools/clang/bindings $PACKAGES_DIR/<LLVM>/
+    cp -R $1/llvm/tools/clang/bindings $PACKAGES_DIR/llvm-<LLVM>/
 }
 ##
 ## End Specifics

--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=1 \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/clang-dbg-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-alt-mpich-gcc
+++ b/build_from_source/template/petsc-alt-mpich-gcc
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-alt-mpich-gcc
+++ b/build_from_source/template/petsc-alt-mpich-gcc
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_ALT>/gcc-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-gcc
 }
 
 post_run() {

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake openmpi-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/clang-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-clang
 }
 
 post_run() {
@@ -75,6 +101,7 @@ setenv      PETSC_DIR        \$BASE_PATH/petsc/openmpi_<PETSC_ALT>/clang-opt-sup
 EOF
     cd $PACKAGES_DIR/Modules/<MODULES>/openmpi_clang
     ln -s ../modulefiles/moose/.openmpi_<PETSC_ALT>-clang <PETSC_ALT>
+
 }
 
 ##

--- a/build_from_source/template/petsc-alt-openmpi-gcc
+++ b/build_from_source/template/petsc-alt-openmpi-gcc
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake openmpi-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-gcc
 }
 
 post_run() {
@@ -75,6 +101,7 @@ setenv      PETSC_DIR        \$BASE_PATH/petsc/openmpi_<PETSC_ALT>/gcc-opt-super
 EOF
     cd $PACKAGES_DIR/Modules/<MODULES>/openmpi_gcc
     ln -s ../modulefiles/moose/.openmpi_<PETSC_ALT>-gcc <PETSC_ALT>
+
 }
 
 ##

--- a/build_from_source/template/petsc-alt-openmpi-gcc
+++ b/build_from_source/template/petsc-alt-openmpi-gcc
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_ALT>.tar.gz'
 EXTRACT='<PETSC_ALT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake openmpi-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=1 \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,18 +73,8 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_ALT>/gcc-dbg-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-gcc
 }
 
 post_run() {

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -39,7 +39,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -15,7 +15,43 @@ ARCH=(Darwin)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64 ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64 \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-64-bit-indices=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--with-blas-lapack-dir=/usr/lib
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
+./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64 \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -36,31 +72,21 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64 ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-64
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.mpich_<PETSC_DEFAULT>-64-clang
 #%Module1.0#####################################################################

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -38,7 +38,7 @@ pre_run() {
 --with-cc=mpicc \
 --with-cxx=mpicxx \
 --with-fc=mpif90 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-metis=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -15,7 +15,42 @@ ARCH=(Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64 ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64 \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-64-bit-indices=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-metis=1 \
+--download-parmetis=1 \
+--with-blas-lapack-dir=/usr/lib
+--download-superlu_dist=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64 \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -36,31 +71,21 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64 ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-64
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-gcc
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.mpich_<PETSC_DEFAULT>-64-gcc
 #%Module1.0#####################################################################

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -40,7 +40,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
---with-blas-lapack-dir=/usr/lib
+--with-blas-lapack-dir=/usr/lib \
 --download-superlu_dist=1 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-mpich-clang
+++ b/build_from_source/template/petsc-default-mpich-clang
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--with-blas-lapack-dir=/usr/lib \
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,31 +73,21 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/clang-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.mpich_<PETSC_DEFAULT>-clang
 #%Module1.0#####################################################################

--- a/build_from_source/template/petsc-default-mpich-gcc
+++ b/build_from_source/template/petsc-default-mpich-gcc
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake mpich-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--with-blas-lapack-dir=/usr/lib \
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,31 +73,21 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/mpich_<PETSC_DEFAULT>/gcc-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-gcc
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.mpich_<PETSC_DEFAULT>-gcc
 #%Module1.0#####################################################################

--- a/build_from_source/template/petsc-default-openmpi-clang
+++ b/build_from_source/template/petsc-default-openmpi-clang
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake openmpi-clang
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--with-blas-lapack-dir=/usr/lib \
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,31 +73,21 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/clang-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-clang
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.openmpi_<PETSC_DEFAULT>-clang
 #%Module1.0#####################################################################

--- a/build_from_source/template/petsc-default-openmpi-gcc
+++ b/build_from_source/template/petsc-default-openmpi-gcc
@@ -15,7 +15,43 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<PETSC_DEFAULT>.tar.gz'
 EXTRACT='<PETSC_DEFAULT>.tar.gz'
-CONFIGURE="./configure \
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu ]; then
+	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu
+    fi
+    unset MODULEPATH
+    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
+    module load advanced_modules cmake openmpi-gcc
+    if [ `uname` = "Darwin" ]; then
+	./configure \
+--prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--with-blas-lapack-dir=/usr/lib \
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -fopenmp' \
+-FFLAGS='-fPIC -fopenmp' \
+-FCFLAGS='-fPIC -fopenmp' \
+-F90FLAGS='-fPIC -fopenmp' \
+-F77FLAGS='-fPIC -fopenmp'
+    else
+	./configure \
 --prefix=$PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu \
 --download-hypre=1 \
 --with-ssl=0 \
@@ -37,33 +73,22 @@ CONFIGURE="./configure \
 -FFLAGS='-fPIC -fopenmp' \
 -FCFLAGS='-fPIC -fopenmp' \
 -F90FLAGS='-fPIC -fopenmp' \
--F77FLAGS='-fPIC -fopenmp'"
-
-BUILD='false'
-INSTALL='false'
-
-pre_run() {
-    if [ -d $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu ]; then
-	rm -rf $PACKAGES_DIR/petsc/openmpi_<PETSC_DEFAULT>/gcc-opt-superlu
+-F77FLAGS='-fPIC -fopenmp'
     fi
-    unset MODULEPATH
-    source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-gcc
 }
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
-	    if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
-	    make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
-	    if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
+	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
+	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     fi
-
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.openmpi_<PETSC_DEFAULT>-gcc
 #%Module1.0#####################################################################
 ##


### PR DESCRIPTION
When building on Darwin machines, use system blas instead of PETSc supplied (downloaded) version.
