### PR TITLE
Fix some module typos

### DIFF
--- a/build_from_source/template/mpich-clang
+++ b/build_from_source/template/mpich-clang
@@ -36,7 +36,7 @@ post_run() {
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<MPICH>_gcc moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc <MPICH>_gcc <OPENMPI>_clang <OPENMPI>_gcc
+conflict moose/.<MPICH>_gcc moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc mpich_gcc openmpi_clang openmpi_gcc
 module load moose/.<CLANG>
 
 set             MPI_PATH                    \$BASE_PATH/mpich/<MPICH>/clang-opt
@@ -66,7 +66,7 @@ EOF
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc <MPICH>_gcc <OPENMPI>_clang <OPENMPI>_gcc
+conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc mpich_gcc openmpi_clang openmpi_gcc
 
 if { ! [ is-loaded clang ] } {
   module load moose/.<CLANG>

--- a/build_from_source/template/mpich-gcc
+++ b/build_from_source/template/mpich-gcc
@@ -37,7 +37,7 @@ post_run() {
 set BASE_PATH   $PACKAGES_DIR
 
 set             MPI_PATH           \$BASE_PATH/mpich/<MPICH>/gcc-opt
-conflict moose/.<MPICH>_clang moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc <MPICH>_clang <OPENMPI>_clang <OPENMPI>_gcc
+conflict moose/.<MPICH>_clang moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc mpich_clang openmpi_clang openmpi_gcc
 module load moose/.<GCC>
 
 prepend-path    C_INCLUDE_PATH     \$MPI_PATH/include
@@ -63,7 +63,7 @@ set BASE_PATH   $PACKAGES_DIR
 
 set             MPI_PATH           \$BASE_PATH/mpich/<MPICH>/gcc-opt
 
-conflict moose/.<MPICH>_gcc moose/.<MPICH>_clang moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc <MPICH>_clang <OPENMPI>_clang <OPENMPI>_gcc
+conflict moose/.<MPICH>_gcc moose/.<MPICH>_clang moose/.<OPENMPI>_clang moose/.<OPENMPI>_gcc mpich_clang openmpi_clang openmpi_gcc
 
 if { ! [ is-loaded <GCC> ] } {
   module load moose/.<GCC>

--- a/build_from_source/template/openmpi-clang
+++ b/build_from_source/template/openmpi-clang
@@ -38,7 +38,7 @@ post_run() {
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc <MPICH>_clang <MPICH>_gcc <OPENMPI>_gcc
+conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc mpich_clang mpich_gcc openmpi_gcc
 module load moose/.<CLANG>
 
 set             MPI_PATH                      \$BASE_PATH/openmpi/<OPENMPI>/clang-opt
@@ -69,7 +69,7 @@ EOF
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<OPENMPI>_clang moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc <MPICH>_clang <MPICH>_gcc <OPENMPI>_gcc
+conflict moose/.<OPENMPI>_clang moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc mpich_clang mpich_gcc openmpi_gcc
 
 if { ! [ is-loaded clang ] } {
   module load moose/.<CLANG>

--- a/build_from_source/template/openmpi-gcc
+++ b/build_from_source/template/openmpi-gcc
@@ -38,7 +38,7 @@ post_run() {
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc <OPENMPI>_clang <MPICH>_clang <MPICH>_gcc
+conflict moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc openmpi_clang mpich_clang mpich_gcc
 module load moose/.<GCC>
 
 set             MPI_PATH           \$BASE_PATH/openmpi/<OPENMPI>/gcc-opt
@@ -69,7 +69,7 @@ EOF
 ##
 set BASE_PATH   $PACKAGES_DIR
 
-conflict moose/.<OPENMPI>_gcc moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc <OPENMPI>_clang <MPICH>_clang <MPICH>_gcc
+conflict moose/.<OPENMPI>_gcc moose/.<MPICH>_clang moose/.<MPICH>_gcc moose/.<OPENMPI>_gcc openmpi_clang mpich_clang mpich_gcc
 
 if { ! [ is-loaded <GCC> ] } {
   module load moose/.<GCC>


### PR DESCRIPTION
Do not look for modules with versions in their name for 'advanced_modules'. Modules located in this hierarchy should always be simple <software>-<arch> identifiers.