### PR TITLE
Move Trilinos source to mooseframework. Build PETSc with one proc

### DIFF
--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all
 	if [ $? -ne 0 ]; then echo 'Failed to build'; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install
 	if [ $? -ne 0 ]; then echo 'Failed to install'; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all
 	if [ $? -ne 0 ]; then echo 'Failed to build'; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install
 	if [ $? -ne 0 ]; then echo 'Failed to install'; cleanup 1; fi

--- a/build_from_source/template/petsc-alt-mpich-gcc
+++ b/build_from_source/template/petsc-alt-mpich-gcc
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-alt-openmpi-gcc
+++ b/build_from_source/template/petsc-alt-openmpi-gcc
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -52,12 +52,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -52,12 +52,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-mpich-clang
+++ b/build_from_source/template/petsc-default-mpich-clang
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-mpich-gcc
+++ b/build_from_source/template/petsc-default-mpich-gcc
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-openmpi-clang
+++ b/build_from_source/template/petsc-default-openmpi-clang
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/petsc-default-openmpi-gcc
+++ b/build_from_source/template/petsc-default-openmpi-gcc
@@ -53,12 +53,12 @@ pre_run() {
 
 post_run() {
     if [ `uname` = "Darwin" ]; then
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi
     else
-	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
+	make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all
 	if [ $? -ne 0 ]; then echo "Error while building PETSc"; cleanup 1; fi
 	make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install
 	if [ $? -ne 0 ]; then echo "Error while installing PETSc"; cleanup 1; fi

--- a/build_from_source/template/trilinos-mpich-clang-dbg
+++ b/build_from_source/template/trilinos-mpich-clang-dbg
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \

--- a/build_from_source/template/trilinos-mpich-clang-opt
+++ b/build_from_source/template/trilinos-mpich-clang-opt
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \

--- a/build_from_source/template/trilinos-mpich-gcc-dbg
+++ b/build_from_source/template/trilinos-mpich-gcc-dbg
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \

--- a/build_from_source/template/trilinos-mpich-gcc-opt
+++ b/build_from_source/template/trilinos-mpich-gcc-opt
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \

--- a/build_from_source/template/trilinos-openmpi-gcc-dbg
+++ b/build_from_source/template/trilinos-openmpi-gcc-dbg
@@ -13,7 +13,7 @@ ARCH=(Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \

--- a/build_from_source/template/trilinos-openmpi-gcc-opt
+++ b/build_from_source/template/trilinos-openmpi-gcc-opt
@@ -13,7 +13,7 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='https://github.com/trilinos/Trilinos/archive/<TRILINOS>.tar.gz'
+DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
 CONFIGURE="
 cmake \


### PR DESCRIPTION
GitHub failed me for consistent access to this file. So moving this one to our mooseframework server for internal distribution only.

Build PETSc using only one proc to try and reduce the rare case of running into a build error (NoneType object has no attribute require)