### PR TITLE
Update Trilinos build

### DIFF
--- a/build_from_source/template/miniconda-dev
+++ b/build_from_source/template/miniconda-dev
@@ -37,7 +37,7 @@ pre_run() {
     PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda config --set ssl_verify false
     PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes
     if [ $? -ne 0 ]; then echo "Failed to update $PACKAGE"; cleanup 1; fi
-    PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 matplotlib pandas numpy scikit-image mock scipy coverage yaml pyyaml pyqt vtk=7.0.0 --yes
+    PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 matplotlib pandas numpy scikit-image mock scipy coverage yaml pyyaml pyqt vtk=7.1.0 --yes
     if [ $? -ne 0 ]; then echo "Failed to install $PACKAGE packages"; cleanup 1; fi
     PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda config --set ssl_verify true
 }

--- a/build_from_source/template/trilinos-mpich-clang-dbg
+++ b/build_from_source/template/trilinos-mpich-clang-dbg
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc llvm mpich-clang)
+DEP=(modules cmake petsc-default-mpich-clang)
 PACKAGE='trilinos-mpich-clang-dbg'
 
 #####
@@ -15,62 +15,102 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg/lib \
--D CMAKE_BUILD_TYPE:STRING=DEBUG \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_DEBUG_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE='false'
 BUILD='true'
 INSTALL='true'
 
 pre_run() {
     if [ -d $PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg ]; then
-	rm -rf $PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg
+        rm -rf $PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
+    module load advanced_modules cmake mpich-clang <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir clang-dbg; cd clang-dbg
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-clang-dbg/lib \
+-D CMAKE_BUILD_TYPE:STRING=DEBUG \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
+    configure
 }
 
 post_run() {
     cat <<EOF > $PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose/.mpich_<TRILINOS>-clang-dbg
 #%Module1.0#####################################################################
 ##
-##  Trilinos MPICH Clang Debug Module 
+##  Trilinos MPICH Clang Debug Module
 ##
 ##
 ##

--- a/build_from_source/template/trilinos-mpich-clang-opt
+++ b/build_from_source/template/trilinos-mpich-clang-opt
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc llvm mpich-clang)
+DEP=(modules cmake petsc-default-mpich-clang)
 PACKAGE='trilinos-mpich-clang-opt'
 
 #####
@@ -15,40 +15,7 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-clang-opt \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-clang-opt/lib \
--D CMAKE_BUILD_TYPE:STRING=RELEASE \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_RELEASE_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE="false"
 BUILD='true'
 INSTALL='true'
 
@@ -58,12 +25,85 @@ pre_run() {
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-clang
+    module load advanced_modules cmake mpich-clang <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir clang-opt; cd clang-opt
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-clang-opt \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-clang-opt/lib \
+-D CMAKE_BUILD_TYPE:STRING=RELEASE \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
+    configure
 }
 
 post_run() {

--- a/build_from_source/template/trilinos-mpich-gcc-dbg
+++ b/build_from_source/template/trilinos-mpich-gcc-dbg
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc mpich-gcc)
+DEP=(modules cmake petsc-default-mpich-gcc)
 PACKAGE='trilinos-mpich-gcc-dbg'
 
 #####
@@ -15,40 +15,7 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-dbg \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-dbg/lib \
--D CMAKE_BUILD_TYPE:STRING=DEBUG \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_DEBUG_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE='false'
 BUILD='true'
 INSTALL='true'
 
@@ -58,12 +25,86 @@ pre_run() {
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-gcc
+    module load advanced_modules cmake mpich-gcc <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir gcc-dbg; cd gcc-dbg
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-dbg \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-dbg/lib \
+-D CMAKE_BUILD_TYPE:STRING=DEBUG \
+-D BUILD_SHARED_LIBS=ON \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
+    configure
 }
 
 post_run() {

--- a/build_from_source/template/trilinos-mpich-gcc-opt
+++ b/build_from_source/template/trilinos-mpich-gcc-opt
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc mpich-gcc)
+DEP=(modules cmake petsc-default-mpich-gcc)
 PACKAGE='trilinos-mpich-gcc-opt'
 
 #####
@@ -15,40 +15,7 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-opt \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-opt/lib \
--D CMAKE_BUILD_TYPE:STRING=RELEASE \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_RELEASE_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE='false'
 BUILD='true'
 INSTALL='true'
 
@@ -58,12 +25,86 @@ pre_run() {
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake mpich-gcc
+    module load advanced_modules cmake mpich-gcc <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir gcc-opt; cd gcc-opt
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-opt \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/mpich-gcc-opt/lib \
+-D CMAKE_BUILD_TYPE:STRING=RELEASE \
+-D BUILD_SHARED_LIBS=ON \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
+    configure
 }
 
 post_run() {

--- a/build_from_source/template/trilinos-openmpi-gcc-dbg
+++ b/build_from_source/template/trilinos-openmpi-gcc-dbg
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc openmpi-gcc)
+DEP=(modules cmake petsc-default-openmpi-gcc)
 PACKAGE='trilinos-openmpi-gcc-dbg'
 
 #####
@@ -15,40 +15,7 @@ ARCH=(Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-dbg \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-dbg/lib \
--D CMAKE_BUILD_TYPE:STRING=DEBUG \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_DEBUG_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_DEBUG_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE='false'
 BUILD='true'
 INSTALL='true'
 
@@ -58,12 +25,86 @@ pre_run() {
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-gcc
+    module load advanced_modules cmake openmpi-gcc <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir gcc-dbg; cd gcc-dbg
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-dbg \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-dbg/lib \
+-D CMAKE_BUILD_TYPE:STRING=DEBUG \
+-D BUILD_SHARED_LIBS=ON \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
+    configure
 }
 
 post_run() {

--- a/build_from_source/template/trilinos-openmpi-gcc-opt
+++ b/build_from_source/template/trilinos-openmpi-gcc-opt
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules cmake gcc openmpi-gcc)
+DEP=(modules cmake petsc-default-openmpi-gcc)
 PACKAGE='trilinos-openmpi-gcc-opt'
 
 #####
@@ -15,40 +15,7 @@ ARCH=(Darwin Linux)
 # This is useful for items like 'autojump' which requires a git clone/checkout
 DOWNLOAD='http://mooseframework.org/source_packages/<TRILINOS>.tar.gz'
 EXTRACT='<TRILINOS>.tar.gz'
-CONFIGURE="
-cmake \
--D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-opt \
--D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-opt/lib \
--D CMAKE_BUILD_TYPE:STRING=RELEASE \
--D BUILD_SHARED_LIBS=ON \
--D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
--D TPL_ENABLE_MPI:BOOL=ON \
--D TPL_ENABLE_MOAB=OFF \
--D TPL_ENABLE_BoostLib=OFF \
--D Trilinos_ENABLE_Ifpack=ON \
--D Trilinos_ENABLE_Ifpack2=ON \
--D Trilinos_ENABLE_Teuchos=ON \
--D Trilinos_ENABLE_ML=ON \
--D Trilinos_ENABLE_NOX=ON \
--D Trilinos_ENABLE_AztecOO=ON \
--D Trilinos_ENABLE_Epetra=ON \
--D Trilinos_ENABLE_EpetraExt=ON \
--D TPL_ENABLE_Libmesh=OFF \
--D MPI_BASE_DIR:PATH=$MPI_HOME \
--D Trilinos_ENABLE_CXX11:BOOL=ON \
--D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
--D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
--D Trilinos_EXTRA_REPOSITORIES=DataTransferKit \
--D DataTransferKit_FIND_DTK_DATA_DIR=../DataTransferKit \
--D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
--D DataTransferKit_ENABLE_DBC:BOOL=ON \
--D DataTransferKit_ENABLE_TESTS:BOOL=ON \
--D DataTransferKit_ENABLE_EXAMPLES:BOOL=ON \
--D CMAKE_Fortran_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_C_FLAGS_RELEASE_OVERRIDE=-fPIC \
--D CMAKE_CXX_FLAGS_RELEASE_OVERRIDE=-fPIC \
-..
-"
+CONFIGURE='false'
 BUILD='true'
 INSTALL='true'
 
@@ -58,12 +25,85 @@ pre_run() {
     fi
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
-    module load advanced_modules cmake openmpi-gcc
+    module load advanced_modules cmake openmpi-gcc <PETSC_DEFAULT>
     git clone https://github.com/ORNL-CEES/DataTransferKit.git
     cd DataTransferKit
     git checkout <DTK>
     cd ../
     mkdir gcc-opt; cd gcc-opt
+    CONFIGURE="
+cmake \
+-D CMAKE_INSTALL_PREFIX:PATH=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-opt \
+-D CMAKE_INSTALL_NAME_DIR:STRING=$PACKAGES_DIR/<TRILINOS>/openmpi-gcc-opt/lib \
+-D CMAKE_BUILD_TYPE:STRING=RELEASE \
+-D BUILD_SHARED_LIBS=ON \
+-D CMAKE_CXX_COMPILER:FILEPATH='mpicxx' \
+-D CMAKE_C_COMPILER:FILEPATH='mpicc' \
+-D CMAKE_Fortran_COMPILER:FILEPATH='mpif90' \
+-D CMAKE_CXX_FLAGS:STRING='-g -Wall -fPIC' \
+-D CMAKE_C_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_Fortran_FLAGS:STRING='-g -fPIC' \
+-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
+-D CMAKE_SKIP_RULE_DEPENDENCY=ON \
+-D BUILD_SHARED_LIBS=ON \
+-D MPI_BASE_DIR:PATH=$MPI_HOME \
+-D DataTransferKit_ENABLE_DBC:BOOL=ON \
+-D DataTransferKit_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_EXTRA_REPOSITORIES='DataTransferKit' \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_ENABLE_TESTS:BOOL=OFF \
+-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
+-D Trilinos_ETI_VERSION_TWO:BOOL=ON \
+-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+-D Trilinos_ENABLE_TpetraCore:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKit:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitIntrepidAdapters:BOOL=ON \
+-D Trilinos_ENABLE_DataTransferKitSTKMeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitMoabAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitLibmeshAdapters:BOOL=OFF \
+-D Trilinos_ENABLE_DataTransferKitClassicDTKAdapters:BOOL=ON \
+-D Trilinos_ENABLE_Epetra:BOOL=ON \
+-D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+-D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+-D Trilinos_ENABLE_AztecOO:BOOL=ON \
+-D Trilinos_ENABLE_Ifpack:BOOL=ON \
+-D Trilinos_ENABLE_ML:BOOL=ON \
+-D Trilinos_ENABLE_NOX:BOOL=ON \
+-D Trilinos_ENABLE_Pike:BOOL=ON \
+-D Trilinos_ENABLE_CXX11:BOOL=ON \
+-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
+-D Trilinos_ENABLE_INSTALL_CMAKE_CONFIG_FILES:BOOL=OFF \
+-D Trilinos_ENABLE_EXPORT_MAKEFILES:BOOL=ON \
+-D Trilinos_DEPS_XML_OUTPUT_FILE:FILEPATH="" \
+-D Trilinos_TPL_SYSTEM_INCLUDE_DIRS:BOOL=ON \
+-D Kokkos_ENABLE_Serial:BOOL=ON \
+-D Kokkos_ENABLE_OpenMP:BOOL=OFF \
+-D Kokkos_ENABLE_Pthread:BOOL=OFF \
+-D Kokkos_ENABLE_Cuda:BOOL=OFF \
+-D Tpetra_INST_DOUBLE:BOOL=ON \
+-D Tpetra_INST_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
+-D Tpetra_INST_COMPLEX_DOUBLE:BOOL=OFF \
+-D Tpetra_INST_INT_UNSIGNED_LONG:BOOL=ON \
+-D Tpetra_INST_INT_INT:BOOL=ON \
+-D Tpetra_INST_INT_UNSIGNED:BOOL=OFF \
+-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
+-D Tpetra_INST_INT_LONG:BOOL=OFF \
+-D Tpetra_INST_SERIAL:BOOL=ON \
+-D Tpetra_INST_OPENMP:BOOL=OFF \
+-D Tpetra_INST_PTHREAD:BOOL=OFF \
+-D Tpetra_INST_CUDA:BOOL=OFF \
+-D TPL_ENABLE_MPI:BOOL=ON \
+-D TPL_ENABLE_HWLOC:BOOL=ON \
+-D TPL_ENABLE_HWLOC=OFF \
+-D TPL_BLAS_LIBRARIES:PATH=$PETSC_DIR/lib/libfblas.a \
+-D TPL_LAPACK_LIBRARIES:PATH=$PETSC_DIR/lib/libflapack.a \
+-D TPL_ENABLE_BoostLib=OFF \
+-D TPL_ENABLE_Boost=OFF \
+..
+"
 }
 
 post_run() {

--- a/common_files/darwin-version_template
+++ b/common_files/darwin-version_template
@@ -1,6 +1,6 @@
 MPICH=mpich-3.2
 OPENMPI=openmpi-1.10.2
-PETSC_DEFAULT=petsc-3.7.4
+PETSC_DEFAULT=petsc-3.7.5
 PETSC_ALT=petsc-3.6.4
 SLEPC_DEFAULT=slepc-3.7.3
 SLEPC_ALT=slepc-3.6.3
@@ -23,7 +23,7 @@ CCACHE=ccache-3.2.1
 TCL=tcl8.5.14
 MODULES=3.2.10
 TRILINOS=trilinos-release-12-6-2
-DTK=b40e1cec6f00760efb1107161df5596f6486429f
+DTK=2.0.0
 PKG_CONFIG=pkg-config-0.29.1
 CAIRO=cairo-1.14.6
 PIXMAN=pixman-0.34.0

--- a/common_files/linux-version_template
+++ b/common_files/linux-version_template
@@ -1,6 +1,6 @@
 MPICH=mpich-3.2
 OPENMPI=openmpi-1.10.2
-PETSC_DEFAULT=petsc-3.7.4
+PETSC_DEFAULT=petsc-3.7.5
 PETSC_ALT=petsc-3.6.4
 SLEPC_DEFAULT=slepc-3.7.3
 SLEPC_ALT=slepc-3.6.3
@@ -23,5 +23,5 @@ CCACHE=ccache-3.2.1
 TCL=tcl8.5.14
 MODULES=3.2.10
 TRILINOS=trilinos-release-12-6-2
-DTK=b40e1cec6f00760efb1107161df5596f6486429f
+DTK=2.0.0
 GITLFS=git-lfs-linux-amd64-1.4.3


### PR DESCRIPTION
Update the way we build Trilinos.
Use DTK tags instead of master branch.
Update VTK dev to 7.1.0.
Update which PETSc superlu-dist is using.