### PR TITLE
More Optimizations

### DIFF
--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -1,6 +1,22 @@
 #!/bin/bash
 ####
 # set common functions
+ccache_enable() {
+    if [ -n "$NO_CCACHE" ]; then return; fi
+    if [ -d /opt/ccache ]; then
+        echo -e "Enabling CCACHE..."
+        export PATH=/opt/ccache/bin:$PATH
+        if [ `uname` == "Darwin" ] && [ "$CC" == "" ]; then
+            CC="clang"; CXX="clang++"
+        elif [ `uname` == "Linux" ] && [  "$CC" == "" ]; then
+            CC="gcc"; CXX="g++"
+        fi
+        export CC="ccache $CC" CXX="ccache $CXX"
+        echo -e "CC=$CC CXX=$CXX"
+        echo "which ccache: "`which ccache`
+    fi
+}
+
 pause() {
     if [ "$DEBUG" = true ]; then
 	read -p "Press Enter to continue.."
@@ -62,6 +78,7 @@ build() {
 	    MOOSE_JOBS=`cat /proc/cpuinfo | grep processor | wc -l`
 	fi
     fi
+    ccache_enable
     make -j $MOOSE_JOBS
     if [ $? -ne 0 ]; then echo 'Failed to make '$1; cleanup 1; fi
     pause
@@ -110,7 +127,8 @@ if [ $CONTINUE = true ]; then
     if [ $DOWNLOAD_ONLY == "True" ]; then
       download
     else
-      export src_temp=`mktemp -d $TEMP_PREFIX/temp_package_builder_$PACKAGE.XXXXXX`
+      export src_temp=$TEMP_PREFIX/$PACKAGE
+      mkdir -p $src_temp
       cd $src_temp
       download
       extract

--- a/build_from_source/make_all.py
+++ b/build_from_source/make_all.py
@@ -244,7 +244,7 @@ if __name__ == '__main__':
   os.environ['PACKAGES_DIR'] = args.prefix
   os.environ['MOOSE_JOBS'] = args.cpu_count
   os.environ['MAX_MODULES'] = args.max_modules
-  os.environ['TEMP_PREFIX'] = tempfile.gettempdir()
+  os.environ['TEMP_PREFIX'] = tempfile.gettempdir() + os.path.sep + 'moose_package_build_temp'
   os.environ['DEBUG'] = 'false'
   if not os.path.exists(download_directory):
     os.makedirs(download_directory)

--- a/build_from_source/template/glib
+++ b/build_from_source/template/glib
@@ -26,7 +26,7 @@ pre_run() {
     unset MODULEPATH
     source $PACKAGES_DIR/Modules/<MODULES>/init/bash
     module load moose-tools
-    CONFIGURE="PATH=$PACKAGES_DIR/pcre/bin:/$PACKAGES_DIR/gettext/bin:$PATH LDFLAGS='-L/opt/moose/gettext/lib' CPPFLAGS='-I/opt/moose/gettext/include' ./configure --prefix=$PACKAGES_DIR/$PACKAGE"
+    CONFIGURE="PATH=$PACKAGES_DIR/pcre/bin:$PACKAGES_DIR/gettext/bin:$PATH LDFLAGS='-L/opt/moose/gettext/lib' CPPFLAGS='-I/opt/moose/gettext/include' ./configure --prefix=$PACKAGES_DIR/$PACKAGE"
 }
 
 post_run() {

--- a/build_from_source/template/pcre
+++ b/build_from_source/template/pcre
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules pkg-config)
+DEP=(modules pkg-config miniconda)
 PACKAGE='pcre'
 
 #####

--- a/create_redistributable/rpm/SPECS/moose-compilers.spec
+++ b/create_redistributable/rpm/SPECS/moose-compilers.spec
@@ -22,7 +22,7 @@ License: None
 Summary: Compilers neccessary to utilize the MOOSE Framework
 Url: http://mooseframework.org
 Group: Development/Libraries
-Source: %{name}.tar
+Source: %{name}.tar.gz
 Requires: gcc gcc-c++ make freeglut-devel m4 blas-devel lapack-devel <REQUIREMENTS>
 BuildRoot: %{_tmppath}/%{name}-build
 AutoReqProv: no


### PR DESCRIPTION
Create a retry routine for some of the basic things that can fail.
Remove the configure line that has Trilinos using PETSc's blas/lapack libs.
Harfbuzz was building before glib, while pango required harfbuzz to have glib.