### PR TITLE
Maintain version control outside of repo

### DIFF
--- a/create_redistributable/create.py
+++ b/create_redistributable/create.py
@@ -64,13 +64,20 @@ Base class for building packages
           version_template[item.split('=')[0]] = item.split('=')[1]
     return version_template
 
+  # Method for maintaining the package version based on package class (pkg, rpm, deb)
   def _get_build_version(self):
-    if not os.path.exists(os.path.join(args.relative_path, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build')):
-      with open(os.path.join(args.relative_path, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build'), 'w') as version_file:
+    if not os.path.exists(os.path.join(args.meta_dir, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build')):
+      if not os.path.exists(os.path.join(args.meta_dir, self.__class__.__name__.lower())):
+        try:
+          os.makedirs(os.path.join(args.meta_dir, self.__class__.__name__.lower()))
+        except OSError:
+          print 'Failed to create versioning meta directory:', args.meta_dir
+          sys.exit(1)
+      with open(os.path.join(args.meta_dir, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build'), 'w') as version_file:
         version_file.write('1')
         return '1'
     else:
-      with open(os.path.join(args.relative_path, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build'), 'r+') as version_file:
+      with open(os.path.join(args.meta_dir, self.__class__.__name__.lower(), self.release + '-' + self.version + '_build'), 'r+') as version_file:
         new_version = int(version_file.read()) + 1
         version_file.truncate(0)
         version_file.seek(0)
@@ -403,6 +410,7 @@ def parseArguments(args=None):
   parser.add_argument('-p', '--packages-dir', help='Directory where you installed everything to (/opt/moose)')
   parser.add_argument('--package-type', help='Specify type of package to build. Valid values: deb rpm pkg')
   parser.add_argument('--force', action='store_const', const=True, default=False, help='Force building package even if script could not determine OS release version')
+  parser.add_argument('--meta-dir', default=os.path.join(os.environ['HOME'], 'package_versioning'), help='Absolute path location to store versioning information')
   parser.add_argument('--sign', help='Sign the package (Macintosh Only) with the specified key')
   parser.add_argument('-k', '--keep-temporary-files', action='store_const', const=True, default=False, help='Keep temporary directory after package is created (default False')
   return verifyArgs(parser.parse_args(args))


### PR DESCRIPTION
Due to the automation of the package builder, we can not create diffs within the repo
to maintain package version. Instead we will maintain versioning information by default
to the would-be users home directory.