### PR TITLE
Include TCL lib dir

### DIFF
--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -26,7 +26,8 @@ try_command() {
         eval "$command_string"
         retcode=$?
         if [ "$retcode" != "0" ] && [ "$try_count" == "$allowed_count" ]; then
-            echo "Failed to execute: $command_string"
+            echo "Failed $1 times, trying to execute: $command_string"
+            cleanup 1
         elif [ "$retcode" != "0" ]; then
             sleep 30
         else

--- a/build_from_source/template/modules
+++ b/build_from_source/template/modules
@@ -16,7 +16,7 @@ ARCH=(Darwin Linux)
 DOWNLOAD='http://mooseframework.org/source_packages/modules-<MODULES>.tar.gz'
 EXTRACT='modules-<MODULES>.tar.gz'
 if [ `uname` = "Darwin" ]; then
-    CONFIGURE="./configure --prefix=$PACKAGES_DIR"
+    CONFIGURE="./configure --prefix=$PACKAGES_DIR --with-tcl=$PACKAGES_DIR/tcl/lib"
 else
     CONFIGURE="CPPFLAGS=-DUSE_INTERP_ERRORLINE ./configure --prefix=$PACKAGES_DIR"
 fi


### PR DESCRIPTION
Running into an issue with Sierra needing this config argument. No effect on El Capitan.