### PR TITLE
Fix try_command for PETSc builds

### DIFF
--- a/build_from_source/template/gcc
+++ b/build_from_source/template/gcc
@@ -66,6 +66,10 @@ prepend-path MANPATH                     \$GCC_PATH/share/man
 setenv       GCC_BIN                     \$GCC_PATH/bin
 setenv       GCC_LIB                     \$GCC_PATH/lib:\$GCC_PATH/lib/i386
 setenv       GCC_MAN                     \$GCC_PATH/share/man
+
+# Allow clang-formatting binary to be available even when not using clang
+prepend-path    PATH    $PACKAGES_DIR/llvm-<LLVM>/bin
+
 EOF
     cd $PACKAGES_DIR/Modules/<MODULES>/adv_modules
     ln -s ../modulefiles/moose/.<GCC> gcc

--- a/build_from_source/template/modules
+++ b/build_from_source/template/modules
@@ -176,9 +176,6 @@ if { [ info exists ::env(MOOSE_DIR) ] } {
     prepend-path PYTHONPATH \$MOOSE_DIR/python
   }
 }
-# Allow clang-formatting binary to be available even when not using clang
-prepend-path    PATH    $PACKAGES_DIR/llvm-<LLVM>/bin
-
 EOF
 }
 ##

--- a/build_from_source/template/petsc-alt-mpich-clang
+++ b/build_from_source/template/petsc-alt-mpich-clang
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install"
     fi
 }
 

--- a/build_from_source/template/petsc-alt-mpich-gcc
+++ b/build_from_source/template/petsc-alt-mpich-gcc
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-alt-openmpi-clang
+++ b/build_from_source/template/petsc-alt-openmpi-clang
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-alt-openmpi-gcc
+++ b/build_from_source/template/petsc-alt-openmpi-gcc
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-darwin-c-debug install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug all; make PETSC_DIR=$1/<PETSC_ALT> PETSC_ARCH=arch-linux2-c-debug install"
     fi
 }
 

--- a/build_from_source/template/petsc-bleedingedge-mpich-clang
+++ b/build_from_source/template/petsc-bleedingedge-mpich-clang
@@ -55,13 +55,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-bleedingedge-mpich-gcc
+++ b/build_from_source/template/petsc-bleedingedge-mpich-gcc
@@ -55,13 +55,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_BLEEDINGEDGE> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -52,13 +52,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -52,13 +52,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-mpich-clang
+++ b/build_from_source/template/petsc-default-mpich-clang
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-mpich-gcc
+++ b/build_from_source/template/petsc-default-mpich-gcc
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-openmpi-clang
+++ b/build_from_source/template/petsc-default-openmpi-clang
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 

--- a/build_from_source/template/petsc-default-openmpi-gcc
+++ b/build_from_source/template/petsc-default-openmpi-gcc
@@ -53,13 +53,10 @@ pre_run() {
 -F90FLAGS='-fPIC -fopenmp' \
 -F77FLAGS='-fPIC -fopenmp'"
 
-    try_command 3 "clean_petsc; configure"
     if [ `uname` = "Darwin" ]; then
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-darwin-c-opt install"
     else
-	try_command 3 "make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all"
-	try_command 3 "make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+	try_command 3 "clean_petsc; configure; make MAKE_NP=1 PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
     fi
 }
 


### PR DESCRIPTION
The PETSc builds were not using the try_command correctly.
When a build fails we need to start over entirely, not try to run the same command that failed previously.