### PR TITLE
Specify specific pylint version

### DIFF
--- a/build_from_source/template/pip-installs
+++ b/build_from_source/template/pip-installs
@@ -27,7 +27,7 @@ pre_run() {
     for which_conda in ${condas[*]}; do
 	module purge
 	module load advanced_modules $which_conda
-	pip install markdown markdown-include python-markdown-math pybtex bs4 jinja2 livereload daemonlite pylint lxml pylatexenc
+	pip install markdown markdown-include python-markdown-math pybtex bs4 jinja2 livereload daemonlite pylint==1.6.5 lxml pylatexenc
 	if [ $? -ne 0 ]; then echo "Failed to install dependency packages for $PACKAGE"; cleanup 1; fi
     done
 }


### PR DESCRIPTION
The latest operating systems are installing pylint 1.7.1 by default
and that appears to break our python pre-check tests.