### PR TITLE
Update Welcome page OS X

### DIFF
--- a/create_redistributable/pkg/OSX/Welcome_Panel.html
+++ b/create_redistributable/pkg/OSX/Welcome_Panel.html
@@ -10,7 +10,6 @@
       <UL>
         <LI><A HREF="https://gcc.gnu.org/"><GCC></A></LI>
         <LI><A HREF="http://clang.llvm.org/">llvm-<LLVM></A></LI>
-        <LI><A HREF="http://www.open-mpi.org/"><OPENMPI></A></LI>
         <LI><A HREF="https://www.mpich.org/"><MPICH></A></LI>
         <LI><A HREF="http://www.mcs.anl.gov/petsc/"><PETSC_DEFAULT>/<PETSC_ALT></A></LI>
         <LI><A HREF="https://trilinos.org/"><TRILINOS></A></LI>


### PR DESCRIPTION
Remove reference to OpenMPI for OS X packages.