### PR TITLE
Updated external seacas package

### DIFF
--- a/build_from_source/template/seacas
+++ b/build_from_source/template/seacas
@@ -24,6 +24,8 @@ pre_run() {
     if [ -d seacas ]; then rm -rf seacas; fi
     try_command 3 "git clone https://github.com/milljm/seacas.git"
     cd seacas
+    # Updated external repository, adding this comment to trigger a change
+    # (build netcdf with X11 support to allow blot to be built)
     git checkout jasons_installer
     if [ $? -ne 0 ]; then echo "Failed to checkout branch"; cleanup 1; fi
     cd contrib


### PR DESCRIPTION
Blot was not being built. Turns out that we _do_ need
X11 enabled. It appears I had previously disabled it
thinking we did not need it enabled (according to git
log).

Closes #119