### PR TITLE
Modify LLDB Python library link

### DIFF
--- a/build_from_source/template/llvm
+++ b/build_from_source/template/llvm
@@ -134,7 +134,7 @@ pre_run() {
 -DLLVM_ENABLE_RTTI=ON \
 -DCMAKE_BUILD_TYPE="Release" \
 -DPYTHON_EXECUTABLE=`which python2.7` \
--DLLDB_DISABLE_PYTHON=1 \
+-DLLDB_DISABLE_PYTHON=0 \
 -DLLVM_TARGETS_TO_BUILD="X86" \
 -Wno-dev \
 ../llvm
@@ -142,7 +142,7 @@ pre_run() {
       cmake -DCMAKE_INSTALL_PREFIX="$PACKAGES_DIR/$PACKAGE" \
 -DLLVM_BUILD_EXTERNAL_COMPILER_RT=ON \
 -DLLDB_CODESIGN_IDENTITY='' \
--DLLDB_DISABLE_PYTHON=1 \
+-DLLDB_DISABLE_PYTHON=0 \
 -DLLVM_ENABLE_RTTI=ON \
 -DCLANG_DEFAULT_OPENMP_RUNTIME=libomp \
 -DPYTHON_EXECUTABLE=`which python2.7` \
@@ -197,6 +197,13 @@ post_run() {
     fi
     ln -s ../modulefiles/moose/.<CLANG> clang
     cd "$PACKAGES_DIR/$PACKAGE/lib"
+
+    # Link to miniconda's python
+    if [ `uname` == "Darwin" ]; then
+        cd "$PACKAGES_DIR/$PACKAGE/lib"
+        install_name_tool -change @rpath/libpython2.7.dylib "$PACKAGES_DIR/miniconda/lib/libpython2.7.dylib" liblldb.5.0.1.dylib
+    fi
+
     change_links
     cp -R "$1/llvm/tools/clang/bindings" "$PACKAGES_DIR/$PACKAGE/"
 }

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -34,7 +34,7 @@ pre_run() {
     fi
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt swig --yes"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify true
 }


### PR DESCRIPTION
LLDB creates a link that is not available during runtime on
darwin machines. Modify this link to point to the absolute
path to libpython (miniconda's).

Because of this, we need to re-enable python support for LLDB