### PR TITLE
Add ability to make the PETSc alt modules visible

### DIFF
--- a/build_from_source/template/modules
+++ b/build_from_source/template/modules
@@ -174,7 +174,7 @@ EOF
 ##
 ##
 ##
-conflict moose-dev-gcc
+conflict moose-dev-clang-alt moose-dev-gcc moose-dev-gcc-alt
 module load moose/.<MPICH>_<CLANG>
 module load moose/.<PETSC_DEFAULT>_<MPICH>_<CLANG>-opt
 module load moose/.<TBB>
@@ -195,9 +195,51 @@ EOF
 ##
 ##
 ##
-conflict moose-dev-clang
+conflict moose-dev-gcc-alt moose-dev-clang moose-dev-clang-alt
 module load moose/.<MPICH>_<GCC>
 module load moose/.<PETSC_DEFAULT>_<MPICH>_<GCC>-opt
+module load moose/.<TBB>
+module load moose/.<CPPUNIT>_<GCC>
+
+# If MOOSE_DIR is set, help the user out by prepending the moose/python path
+if { [ info exists ::env(MOOSE_DIR) ] } {
+  eval set [ array get env MOOSE_DIR ]
+  if [ file isdirectory "\$MOOSE_DIR/python" ] {
+    prepend-path PYTHONPATH "\$MOOSE_DIR/python"
+  }
+}
+EOF
+    cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose-dev-clang-alt"
+#%Module1.0#####################################################################
+##
+## Clang MOOSE DEV ALT Module
+##
+##
+##
+conflict moose-dev-clang moose-dev-gcc moose-dev-alt
+module load moose/.<MPICH>_<CLANG>
+module load moose/.<PETSC_ALT>_<MPICH>_<CLANG>-opt
+module load moose/.<TBB>
+module load moose/.<CPPUNIT>_<CLANG>
+
+# If MOOSE_DIR is set, help the user out by prepending the moose/python path
+if { [ info exists ::env(MOOSE_DIR) ] } {
+  eval set [ array get env MOOSE_DIR ]
+  if [ file isdirectory "\$MOOSE_DIR/python" ] {
+    prepend-path PYTHONPATH "\$MOOSE_DIR/python"
+  }
+}
+EOF
+    cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/modulefiles/moose-dev-gcc-alt"
+#%Module1.0#####################################################################
+##
+## GCC MOOSE DEV ALT Module
+##
+##
+##
+conflict moose-dev-gcc moose-dev-clang moose-dev-clang-alt
+module load moose/.<MPICH>_<GCC>
+module load moose/.<PETSC_ALT>_<MPICH>_<GCC>-opt
 module load moose/.<TBB>
 module load moose/.<CPPUNIT>_<GCC>
 

--- a/build_from_source/template/trilinos-mpich-clang-dbg
+++ b/build_from_source/template/trilinos-mpich-clang-dbg
@@ -201,7 +201,8 @@ module load moose-tools
 
 EOF
 
-    cd "$PACKAGES_DIR/Modules/3.2.10/mpich_clang; rm <TRILINOS>-dbg"
+    cd "$PACKAGES_DIR/Modules/3.2.10/mpich_clang"
+    rm <TRILINOS>-dbg
     ln -s ../modulefiles/moose/.<MPICH>_<CLANG>_<TRILINOS>-dbg <TRILINOS>-dbg
 
     TRILINOS_INCLUDE="$PACKAGES_DIR/<TRILINOS>/<MPICH>_<CLANG>-dbg/include"

--- a/build_from_source/template/trilinos-mpich-clang-opt
+++ b/build_from_source/template/trilinos-mpich-clang-opt
@@ -201,7 +201,8 @@ module load moose-tools
 
 EOF
 
-    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_clang; rm <TRILINOS>-opt"
+    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_clang"
+    rm <TRILINOS>-opt
     ln -s ../modulefiles/moose/.<MPICH>_<CLANG>_<TRILINOS>-opt <TRILINOS>-opt
 
     TRILINOS_INCLUDE="$PACKAGES_DIR/<TRILINOS>/<MPICH>_<CLANG>-opt/include"

--- a/build_from_source/template/trilinos-mpich-gcc-dbg
+++ b/build_from_source/template/trilinos-mpich-gcc-dbg
@@ -210,7 +210,8 @@ module load moose-tools
 
 EOF
 
-    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_gcc; rm <TRILINOS>-dbg"
+    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_gcc"
+    rm <TRILINOS>-dbg
     ln -s ../modulefiles/moose/.<MPICH>_<GCC>_<TRILINOS>-dbg <TRILINOS>-dbg
 
     TRILINOS_INCLUDE="$PACKAGES_DIR/<TRILINOS>/<MPICH>_<GCC>-dbg/include"

--- a/build_from_source/template/trilinos-mpich-gcc-opt
+++ b/build_from_source/template/trilinos-mpich-gcc-opt
@@ -209,7 +209,8 @@ module load ccache
 module load moose-tools
 
 EOF
-    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_gcc; rm <TRILINOS>-opt"
+    cd "$PACKAGES_DIR/Modules/<MODULES>/mpich_gcc"
+    rm <TRILINOS>-opt
     ln -s ../modulefiles/moose/.<MPICH>_<GCC>_<TRILINOS>-opt <TRILINOS>-opt
 
     TRILINOS_INCLUDE="$PACKAGES_DIR/<TRILINOS>/<MPICH>_<GCC>-opt/include"

--- a/build_from_source/template/valgrind
+++ b/build_from_source/template/valgrind
@@ -22,7 +22,7 @@ INSTALL='true'
 
 pre_run() {
     if [ `uname` = "Darwin" ] && [ `uname -r | grep -c ^17.` -ge 1 ]; then
-        echo "$PACKAGE not supported on High Sierra"
+        echo "$PACKAGE not supported on High Sierra..."
         cleanup 0
     fi
     cat << 'EOF' > darwin.patch


### PR DESCRIPTION
Adding the ability to have the associated moose-dev-gcc|clang modules
support the alternate version of PETSc with out having to load
multiple modules to make them available.

Fix issue with trilinos module creation.

Closes #139