### PR TITLE
Make sjs compatible with latest QueueManager

### DIFF
--- a/build_from_source/template/sjs
+++ b/build_from_source/template/sjs
@@ -22,6 +22,7 @@ INSTALL='false'
 
 pre_run() {
     cd $PACKAGES_DIR
+    # new commit into sjs to allow new queueing system to function
     try_command 3 "git clone https://github.com/milljm/sjs.git"
     cd sjs
     git checkout pbs


### PR DESCRIPTION
There is a separate commit into the sjs/pbs branch which
contains changes that will allow PBS functionality with
latest QueueManager.