### PR TITLE
Use a tempfile instead of subprocess buffer

### DIFF
--- a/create_redistributable/create.py
+++ b/create_redistributable/create.py
@@ -174,15 +174,16 @@ Class for building Debian based packages
 
   def create_redistributable(self):
     print 'Building redistributable using dpkg... This can take a long time'
+    f = tempfile.TemporaryFile()
     os.chdir(self.temp_dir)
     package_builder = subprocess.Popen(['dpkg', '-b', 'deb'],
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
+                                       stdout=f,
+                                       stderr=f)
     while package_builder.poll() == None:
       time.sleep(1)
-    results = package_builder.communicate()
+    f.seek(0)
     if package_builder.poll() != 0:
-      print 'There was error building the redistributable package using dpkg:\n\n', results[1]
+      print 'There was error building the redistributable package using dpkg:\n\n', f.read()
       return False
     else:
       shutil.move(os.path.join(self.temp_dir, 'deb.deb'), os.path.join(self.args.relative_path, self.redistributable_name))
@@ -260,6 +261,7 @@ Class for building RedHat based packages
 
   def create_redistributable(self):
     print 'Building redistributable using rpmbuild... This can take a long time'
+    f = tempfile.TemporaryFile()
     os.chdir(self.temp_dir)
     os.environ['NO_BRP_CHECK_RPATH'] = 'true'
     os.environ['QA_SKIP_RPATHS'] = 'true'
@@ -267,13 +269,13 @@ Class for building RedHat based packages
     package_builder = subprocess.Popen(['rpmbuild', '-bb',
                                         '--define=_topdir %s' % (os.path.join(self.temp_dir, 'rpm')),
                                         os.path.join(self.temp_dir, 'rpm/SPECS/moose-compilers.spec')],
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
+                                       stdout=f,
+                                       stderr=f)
     while package_builder.poll() == None:
       time.sleep(1)
-    results = package_builder.communicate()
+    f.seek(0)
     if package_builder.poll() != 0:
-      print 'There was error building the redistributable package using rpmbuild:\n\n', results[1]
+      print 'There was error building the redistributable package using rpmbuild:\n\n', f.read()
       return False
     else:
       # There is only going to be one file in the following location

--- a/create_redistributable/pkg/OSX/icecream_post.sh
+++ b/create_redistributable/pkg/OSX/icecream_post.sh
@@ -21,10 +21,11 @@ else
     CPU_COUNT=0
 fi
 
-if ! [ -f /Library/LaunchDaemons/com.moose.icecream.plist ]; then
+# true if file does not exists, or is empty
+if ! [ -f /Library/LaunchDaemons/com.moose.icecream.plist ] || [ -s /Library/LaunchDaemons/com.moose.icecream.plist ]; then
     sed -e "s/<CHANGEME>/`hostname | cut -d. -f1`_$USER/g" <PACKAGES_DIR>/com.moose.icecream.plist | \
-        sed -e "s/<CPUS>/$CPU_COUNT/g" /Library/LaunchDaemons/com.moose.icecream.plist | \
-        sed -e "s/<PACKAGE_PREFIX>/<PACKAGES_DIR>/g" > /Library/LaunchDaemons/com.moose.icecream.plist
+        sed -e "s/<CPUS>/$CPU_COUNT/g" | \
+        sed -e "s|<PACKAGE_PREFIX>|<PACKAGES_DIR>|g" > /Library/LaunchDaemons/com.moose.icecream.plist
     chown root:wheel /Library/LaunchDaemons/com.moose.icecream.plist
     launchctl load /Library/LaunchDaemons/com.moose.icecream.plist
 else


### PR DESCRIPTION
If the output of subprocess if large enough, it will hang and wait for someone to communicate with
it (to empty the buffer). This is was what was happening on our Fedora 28 VM, causing it to hang.
(https://docs.python.org/2/library/subprocess.html#popen-objects)