### PR TITLE
Allow a separate intel stack

### DIFF
--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -1,6 +1,16 @@
 #!/bin/bash
 ####
 # set common functions
+
+source_intel() {
+    if [ "$WITH_INTEL" != "None" ] && [ -f "$WITH_INTEL/bin/compilervars.sh" ]; then
+        source "$WITH_INTEL/bin/compilervars.sh" intel64
+        if [ "$?" == "0" ]; then
+            INTEL_AVAILABLE=true
+        fi
+    fi
+}
+
 ccache_enable() {
     # We do not want to perform any ccache builds
     return
@@ -333,9 +343,20 @@ PROGRESS="$RELATIVE_DIR/progress"
 touch $PROGRESS
 export src_temp="$TEMP_PREFIX/$ME"
 
+if [ -n "$WITH_INTEL" ] && [ "$WITH_INTEL" != "None" ]; then source_intel; fi
+
 CONTINUE="false"
 for OPERATING_SYSTEM in ${ARCH[*]}; do
-    if [ "$OPERATING_SYSTEM" = `uname` ]; then CONTINUE="true"; fi
+    if [ "$OPERATING_SYSTEM" = `uname` ]; then
+        if [ -n "$INTEL_AVAILABLE" ]; then
+            CONTINUE="true"
+        elif [ -z "$WITH_INTEL" ]; then
+            CONTINUE="true"
+        else
+            echo "Intel specified but is not available"
+            cleanup 1
+        fi
+    fi
 done
 
 if [ "$DOWNLOAD_ONLY" = "True" ]; then

--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -358,9 +358,13 @@ CONTINUE="false"
 for OPERATING_SYSTEM in ${ARCH[*]}; do
     if [ "$OPERATING_SYSTEM" == `uname` ]; then
         if [ -n "$WITH_INTEL" ] && [ "$WITH_INTEL" != "None" ]; then
-             source_intel
+            source_intel
             if [ "$INTEL_AVAILABLE" == "true" ]; then
                 CONTINUE=true
+
+            elif [ -z "$SUPPORTED" ]; then
+                echo "Intel not supported on this platform"
+                break
 
             # Intel module, and intel is enabled. The compiler however, is not available.
             else

--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -4,9 +4,20 @@
 
 source_intel() {
     if [ `uname` == "Linux" ] && [ "$WITH_INTEL" != "None" ] && [ -f "$WITH_INTEL/bin/compilervars.sh" ]; then
-        source "$WITH_INTEL/bin/compilervars.sh" intel64
-        if [ "$?" == "0" ]; then
-            INTEL_AVAILABLE=true
+        # jointly supported OS's for intel compilers:
+        supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
+        for supported_arch in ${supported_intel_archs[*]}; do
+            if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
+                SUPPORTED=true
+                break
+            fi
+        done
+
+        if [ -n "$SUPPORTED" ]; then
+            source "$WITH_INTEL/bin/compilervars.sh" intel64
+            if [ "$?" == "0" ]; then
+                INTEL_AVAILABLE=true
+            fi
         fi
     fi
 }

--- a/build_from_source/functions
+++ b/build_from_source/functions
@@ -3,7 +3,7 @@
 # set common functions
 
 source_intel() {
-    if [ "$WITH_INTEL" != "None" ] && [ -f "$WITH_INTEL/bin/compilervars.sh" ]; then
+    if [ `uname` == "Linux" ] && [ "$WITH_INTEL" != "None" ] && [ -f "$WITH_INTEL/bin/compilervars.sh" ]; then
         source "$WITH_INTEL/bin/compilervars.sh" intel64
         if [ "$?" == "0" ]; then
             INTEL_AVAILABLE=true
@@ -343,22 +343,29 @@ PROGRESS="$RELATIVE_DIR/progress"
 touch $PROGRESS
 export src_temp="$TEMP_PREFIX/$ME"
 
-if [ -n "$WITH_INTEL" ] && [ "$WITH_INTEL" != "None" ]; then source_intel; fi
-
 CONTINUE="false"
 for OPERATING_SYSTEM in ${ARCH[*]}; do
-    if [ "$OPERATING_SYSTEM" = `uname` ]; then
-        if [ -n "$INTEL_AVAILABLE" ]; then
-            CONTINUE="true"
-        elif [ -z "$WITH_INTEL" ]; then
-            CONTINUE="true"
+    if [ "$OPERATING_SYSTEM" == `uname` ]; then
+        if [ -n "$WITH_INTEL" ] && [ "$WITH_INTEL" != "None" ]; then
+             source_intel
+            if [ "$INTEL_AVAILABLE" == "true" ]; then
+                CONTINUE=true
+
+            # Intel module, and intel is enabled. The compiler however, is not available.
+            else
+                echo "Intel specified but not available"
+                cleanup 1
+            fi
+
+        # This is an Intel module, but intel is not enabled (skip it)
+        elif [ "$WITH_INTEL" == "None" ]; then
+             CONTINUE=false
         else
-            echo "Intel specified but is not available"
-            cleanup 1
+             CONTINUE=true
         fi
+        break
     fi
 done
-
 if [ "$DOWNLOAD_ONLY" = "True" ]; then
     if [ "$CONTINUE" = "true" ]; then
         download

--- a/build_from_source/make_all.py
+++ b/build_from_source/make_all.py
@@ -161,23 +161,33 @@ def verifyArgs(args):
     if args.dryrun or args.download_only:
         return args
 
-    if args.prefix is None:
-        print 'You must specify a directory to install everything into'
+    if args.with_intel64 and not os.path.exists(args.with_intel64):
+        print 'Intel compilers do not exist at specified location: %s' % (args.with_intel64)
         sys.exit(1)
-    elif os.path.exists(args.prefix) is not True:
-        try:
-            os.makedirs(args.prefix)
-        except:
-            print 'The path specified does not exist. Please create this path, and chown it appropriately before continuing'
+
+    paths = [args.prefix]
+    if args.with_intel64:
+        print 'Opting to build supported modules with an Intel compiler... We will separate this build accordingly.'
+        paths.append(args.prefix.replace(os.path.basename(args.prefix.rstrip(os.path.sep)), os.path.basename(args.prefix.rstrip(os.path.sep) + '_intel')))
+
+    for path in paths:
+        if path is None:
+            print 'You must specify a prefix directory'
             sys.exit(1)
-    else:
-        try:
-            test_writeable = open(os.path.join(args.prefix, 'test_write'), 'a')
-            test_writeable.close()
-            os.remove(os.path.join(args.prefix, 'test_write'))
-        except:
-            print 'Unable to write to specified prefix location. Please chown this location manually before continuing'
-            sys.exit(1)
+        elif os.path.exists(path) is not True:
+            try:
+                os.makedirs(path)
+            except:
+                print 'The path specified does not exist. Please create this path, and chown it appropriately before continuing'
+                sys.exit(1)
+        else:
+            try:
+                test_writeable = open(os.path.join(path, 'test_write'), 'a')
+                test_writeable.close()
+                os.remove(os.path.join(path, 'test_write'))
+            except:
+                print 'Unable to write to specified prefix location. Please chown this location manually before continuing'
+                sys.exit(1)
 
     if args.code_sign_name and not args.code_sign_cert:
         print 'Codesign name supplied but not a path to the certificate'
@@ -197,6 +207,7 @@ def parseArguments(args=None):
     parser.add_argument('-p', '--prefix', help='Directory to install everything into')
     parser.add_argument('-j', '--cpu-count', default='4', help='Specify MAX CPU count available')
     parser.add_argument('-m', '--max-modules', default='2', help='Specify the maximum amount of modules to run simultaneously')
+    parser.add_argument('--with-intel64', nargs='?', const='/opt/intel', default=None, help='Enable Intel compilers. Specify root path to Intel compilers or leave blank to default to /opt/intel')
     parser.add_argument('--code-sign-name', help='Keychain code signing certificate name available to sign LLDB with (OS X Only)')
     parser.add_argument('--code-sign-cert', help='Path to code signing certificate to include for redistribution (for use with OS X codesign)')
     parser.add_argument('--build-only', help='Build only the necessary things up to specified package')
@@ -252,7 +263,8 @@ if __name__ == '__main__':
                           ('MOOSE_JOBS', args.cpu_count),
                           ('KEEP_FAILED', str(args.keep_failed)),
                           ('CODESIGN_NAME', args.code_sign_name),
-                          ('CODESIGN_CERT', args.code_sign_cert)]
+                          ('CODESIGN_CERT', args.code_sign_cert),
+                          ('WITH_INTEL', args.with_intel64)]
 
     templates = getTemplate(args)
     packages_path = alterVersions(templates, args)

--- a/build_from_source/make_all.py
+++ b/build_from_source/make_all.py
@@ -264,7 +264,7 @@ if __name__ == '__main__':
                           ('KEEP_FAILED', str(args.keep_failed)),
                           ('CODESIGN_NAME', args.code_sign_name),
                           ('CODESIGN_CERT', args.code_sign_cert),
-                          ('WITH_INTEL', args.with_intel64)]
+                          ('WITH_INTEL', str(args.with_intel64))]
 
     templates = getTemplate(args)
     packages_path = alterVersions(templates, args)

--- a/build_from_source/template/cppunit-intel
+++ b/build_from_source/template/cppunit-intel
@@ -14,7 +14,7 @@ ARCH=(Linux)
 # jointly supported OS's for intel compilers:
 supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
 for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
         WITH_INTEL=<WITH_INTEL>
     fi
 done

--- a/build_from_source/template/cppunit-intel
+++ b/build_from_source/template/cppunit-intel
@@ -1,0 +1,75 @@
+#!/bin/bash
+#############
+## Specifics
+##
+DEP=(modules gcc intel-module)
+PACKAGE="<INTEL>"
+BASE_DIR="<CPPUNIT>"
+
+#####
+# Set the operating system allowed to build this module
+#
+ARCH=(Linux)
+
+#####
+# Setting any of these variables to 'false' effectively skips that step
+# This is useful for items like 'autojump' which requires a git clone/checkout
+DOWNLOAD='http://mooseframework.inl.gov/source_packages/<CPPUNIT>.tar.gz'
+EXTRACT='<CPPUNIT>.tar.gz'
+CONFIGURE='false'
+BUILD='true'
+INSTALL='true'
+
+pre_run() {
+    if [ -d "${PACKAGES_DIR}_intel/$BASE_DIR/$PACKAGE" ]; then rm -rf "${PACKAGES_DIR}_intel/$BASE_DIR/$PACKAGE"; fi
+    CONFIGURE="./configure --prefix=${PACKAGES_DIR}_intel/$BASE_DIR/$PACKAGE"
+    unset MODULEPATH
+    source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
+    module load moose/.<GCC>
+    export CC=icc
+    export CXX=icpc
+}
+
+post_run() {
+    cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/<CPPUNIT>_<INTEL>"
+#%Module1.0#####################################################################
+##
+## <CPPUNIT> <INTEL>
+##
+set          BASE_PATH         "${PACKAGES_DIR}_intel"
+conflict moose/.<CPPUNIT>_<CLANG> cppunit-clang moose/.<CPPUNIT>_<GCC> cppunit-gcc
+
+set          CPPUNIT_PATH      "\$BASE_PATH/<CPPUNIT>/<INTEL>"
+setenv       CPPUNIT_DIR       "\$CPPUNIT_PATH"
+
+prepend-path INCLUDE           "\$CPPUNIT_PATH/include"
+prepend-path PATH              "\$CPPUNIT_PATH/bin"
+module load <INTEL>
+EOF
+}
+##
+## End Specifics
+##############
+## The following script contains all the common functions.
+## Those functions are executed in the following order:
+
+# download
+# extract
+# pre-run
+# configure
+# make
+# make install
+# post_run
+# cleanup
+
+## pre_run and post_run are the only true specifics that are different
+## with every package
+PACKAGES_DIR="<PACKAGES_DIR>"
+RELATIVE_DIR="<RELATIVE_DIR>"
+DOWNLOAD_DIR="<DOWNLOAD_DIR>"
+TEMP_PREFIX="<TEMP_PREFIX>"
+MOOSE_JOBS=<MOOSE_JOBS>
+KEEP_FAILED=<KEEP_FAILED>
+DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
+source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/cppunit-intel
+++ b/build_from_source/template/cppunit-intel
@@ -11,14 +11,6 @@ BASE_DIR="<CPPUNIT>"
 #
 ARCH=(Linux)
 
-# jointly supported OS's for intel compilers:
-supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
-for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
-        WITH_INTEL=<WITH_INTEL>
-    fi
-done
-
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
@@ -82,4 +74,5 @@ TEMP_PREFIX="<TEMP_PREFIX>"
 MOOSE_JOBS=<MOOSE_JOBS>
 KEEP_FAILED=<KEEP_FAILED>
 DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
 source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/cppunit-intel
+++ b/build_from_source/template/cppunit-intel
@@ -26,6 +26,9 @@ pre_run() {
     unset MODULEPATH
     source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
     module load moose/.<GCC>
+    export CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export CPATH=/usr/include/x86_64-linux-gnu
     export CC=icc
     export CXX=icpc
 }

--- a/build_from_source/template/cppunit-intel
+++ b/build_from_source/template/cppunit-intel
@@ -11,6 +11,14 @@ BASE_DIR="<CPPUNIT>"
 #
 ARCH=(Linux)
 
+# jointly supported OS's for intel compilers:
+supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
+for supported_arch in ${supported_intel_archs[*]}; do
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+        WITH_INTEL=<WITH_INTEL>
+    fi
+done
+
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
@@ -74,5 +82,4 @@ TEMP_PREFIX="<TEMP_PREFIX>"
 MOOSE_JOBS=<MOOSE_JOBS>
 KEEP_FAILED=<KEEP_FAILED>
 DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
-WITH_INTEL=<WITH_INTEL>
 source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/intel-module
+++ b/build_from_source/template/intel-module
@@ -13,7 +13,7 @@ ARCH=(Linux)
 # jointly supported OS's for intel compilers:
 supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
 for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
         WITH_INTEL=<WITH_INTEL>
     fi
 done

--- a/build_from_source/template/intel-module
+++ b/build_from_source/template/intel-module
@@ -1,0 +1,114 @@
+#!/bin/bash
+#############
+## Specifics
+##
+DEP=(modules gcc ccache miniconda)
+PACKAGE="<INTEL>"
+
+#####
+# Set the operating system allowed to build this module
+#
+ARCH=(Linux)
+
+#####
+# Setting any of these variables to 'false' effectively skips that step
+# This is useful for items like 'autojump' which requires a git clone/checkout
+DOWNLOAD='false'
+EXTRACT='false'
+CONFIGURE='false'
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+  return
+}
+
+post_run() {
+    cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/<INTEL>"
+#%Module1.0#####################################################################
+##
+## Intel 2018 miodulefile
+##
+##
+##
+
+set          BASE_PATH          <WITH_INTEL>
+set          COMPILER_VER       compilers_and_libraries_2018.1.163
+
+setenv       MKLROOT            \$BASE_PATH/\$COMPILER_VER/mkl
+setenv       INTEL_LICENSE_FILE \$BASE_PATH/licenses
+setenv       IPPROOT            \$BASE_PATH/\$COMPILER_VER/ipp
+setenv       FPATH              \$BASE_PATH/\$COMPILER_VER/mkl/include
+
+setenv       CPATH              \$BASE_PATH/\$COMPILER_VER/linux/ipp/include:\$BASE_PATH/\$COMPILER_VER/linux/mkl/include:\$BASE_PATH/\$COMPILER_VER/linux/pstl/include:\$BASE_PATH/\$COMPILER_VER/linux/tbb/include:\$BASE_PATH/\$COMPILER_VER/linux/daal/include
+setenv       GDBSERVER_MIC      \$BASE_PATH/debugger_2018/gdb/targets/intel64/x200/bin/gdbserver
+
+setenv       LIBRARY_PATH       \$BASE_PATH/\$COMPILER_VER/linux/ipp/lib/intel64:\$BASE_PATH/\$COMPILER_VER/linux/compiler/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/mkl/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/tbb/lib/intel64/gcc4.7:\$BASE_PATH/\$COMPILER_VER/linux/daal/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+
+setenv       LD_LIBRARY_PATH    \$BASE_PATH/\$COMPILER_VER/linux/compiler/lib/intel64:\$BASE_PATH/\$COMPILER_VER/linux/compiler/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/mpi/intel64/lib:\$BASE_PATH/\$COMPILER_VER/linux/mpi/mic/lib:\$BASE_PATH/\$COMPILER_VER/linux/ipp/lib/intel64:\$BASE_PATH/\$COMPILER_VER/linux/mkl/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/tbb/lib/intel64/gcc4.7:\$BASE_PATH/debugger_2018/iga/lib:\$BASE_PATH/debugger_2018/libipt/intel64/lib:\$BASE_PATH/\$COMPILER_VER/linux/daal/lib/intel64_lin:\$BASE_PATH/\$COMPILER_VER/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+
+setenv       PSTLROOT           \$BASE_PATH/\$COMPILER_VER/linux/pstl
+setenv       NLSPATH            \$BASE_PATH/\$COMPILER_VER/linux/compiler/lib/intel64/locale/%l_%t/%N:\$BASE_PATH/\$COMPILER_VER/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:\$BASE_PATH/debugger_2018/gdb/intel64/share/locale/%l_%t/%N
+
+prepend-path PATH               \$BASE_PATH/\$COMPILER_VER/linux/bin/intel64:\$BASE_PATH/\$COMPILER_VER/linux/mpi/intel64/bin
+setenv       TBBROOT            \$BASE_PATH/\$COMPILER_VER/linux/tbb
+setenv       GDBCROSS           \$BASE_PATH/debugger_2018/gdb/intel64/bin/gdb-ia
+setenv       DAALROOT           \$BASE_PATH/\$COMPILER_VER/linux/daal
+setenv       MPM_LAUNCHER       \$BASE_PATH/debugger_2018/mpm/mic/bin/start_mpm.sh
+setenv       INTEL_PYTHONHOME   \$BASE_PATH/debugger_2018/python/intel64/
+setenv       CLASSPATH          \$BASE_PATH/\$COMPILER_VER/linux/mpi/intel64/lib/mpi.jar:\$BASE_PATH/\$COMPILER_VER/linux/daal/lib/daal.jar
+prepend-path PKG_CONFIG_PATH    \$BASE_PATH/\$COMPILER_VER/linux/mkl/bin/pkgconfig
+setenv       INFOPATH           \$BASE_PATH/\$COMPILER_VER/en/debugger/gdb-ia/info/:\$BASE_PATH/\$COMPILER_VER/en/debugger/gdb-igfx/info/
+setenv       I_MPI_ROOT         \$BASE_PATH/\$COMPILER_VER/linux/mpi
+
+
+# Intel indeed uses what ever GCC is within PATH
+module load moose/.<GCC>
+
+# We need these paths included so sys/cdefs is available
+prepend-path CPLUS_INCLUDE_PATH   /usr/include/x86_64-linux-gnu
+prepend-path C_INCLUDE_PATH       /usr/include/x86_64-linux-gnu
+prepend-path CPATH                /usr/include/x86_64-linux-gnu
+EOF
+
+    cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/moose-dev-intel"
+#%Module1.0#####################################################################
+##
+## <PETSC_DEFAULT>
+## <INTEL>
+## <MPICH>
+##
+module load <MPICH>_<INTEL>
+module load <PETSC_DEFAULT>_<MPICH>_<INTEL>-opt
+module load <CPPUNIT>_<INTEL>
+module load ccache
+module load moose-tools
+
+EOF
+}
+##
+## End Specifics
+##############
+## The following script contains all the common functions.
+## Those functions are executed in the following order:
+
+# download
+# extract
+# pre-run
+# configure
+# make
+# make install
+# post_run
+# cleanup
+
+## pre_run and post_run are the only true specifics that are different
+## with every package
+PACKAGES_DIR="<PACKAGES_DIR>"
+RELATIVE_DIR="<RELATIVE_DIR>"
+DOWNLOAD_DIR="<DOWNLOAD_DIR>"
+TEMP_PREFIX="<TEMP_PREFIX>"
+MOOSE_JOBS=<MOOSE_JOBS>
+KEEP_FAILED=<KEEP_FAILED>
+DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
+source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/intel-module
+++ b/build_from_source/template/intel-module
@@ -10,14 +10,6 @@ PACKAGE="<INTEL>"
 #
 ARCH=(Linux)
 
-# jointly supported OS's for intel compilers:
-supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
-for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
-        WITH_INTEL=<WITH_INTEL>
-    fi
-done
-
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout

--- a/build_from_source/template/intel-module
+++ b/build_from_source/template/intel-module
@@ -10,6 +10,14 @@ PACKAGE="<INTEL>"
 #
 ARCH=(Linux)
 
+# jointly supported OS's for intel compilers:
+supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
+for supported_arch in ${supported_intel_archs[*]}; do
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+        WITH_INTEL=<WITH_INTEL>
+    fi
+done
+
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout

--- a/build_from_source/template/mpich-intel
+++ b/build_from_source/template/mpich-intel
@@ -1,0 +1,99 @@
+#!/bin/bash
+#############
+## Specifics
+##
+DEP=(modules gcc intel-module)
+PACKAGE="<INTEL>"
+BASE_DIR="<MPICH>"
+
+#####
+# Set the operating system allowed to build this module
+#
+ARCH=(Linux)
+
+#####
+# Setting any of these variables to 'false' effectively skips that step
+# This is useful for items like 'autojump' which requires a git clone/checkout
+DOWNLOAD='http://mooseframework.inl.gov/source_packages/<MPICH>.tar.gz'
+EXTRACT='<MPICH>.tar.gz'
+CONFIGURE='false'
+BUILD='true'
+INSTALL='true'
+
+pre_run() {
+    if [ -d "${PACKAGES_DIR}_intel/$BASE_DIR/<INTEL>" ]; then rm -rf "${PACKAGES_DIR}_intel/$BASE_DIR/<INTEL>"; fi
+    mkdir intel-opt; cd intel-opt
+    unset MODULEPATH
+    source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
+    module load moose/.<GCC>
+    export CC=icc CXX=icpc FC=ifort F77=ifort
+    CONFIGURE="../configure --prefix=${PACKAGES_DIR}_intel/<MPICH>/<INTEL> --enable-shared --enable-sharedlibs=gcc --enable-fast=03 --enable-debuginfo --enable-totalview --enable-two-level-namespace CC=icc CXX=icpc FC=ifort F77=ifort F90='' CFLAGS='' CXXFLAGS='' FFLAGS='' FCFLAGS='' F90FLAGS='' F77FLAGS=''"
+}
+post_run() {
+    cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/<MPICH>_<INTEL>"
+#%Module1.0#####################################################################
+##
+## <MPICH> <INTEL>
+##
+set BASE_PATH   "${PACKAGES_DIR}_intel"
+
+set             MPI_PATH           "\$BASE_PATH/<MPICH>/<INTEL>"
+
+conflict moose/.<MPICH>_<GCC> moose/.<MPICH>_<CLANG> moose/.<OPENMPI>_<CLANG> moose/.<OPENMPI>_<GCC> mpich_clang openmpi_clang openmpi_gcc
+
+if { ! [ is-loaded <GCC> ] || ! [ is-loaded moose/.<GCC> ] } {
+  module load moose/.<GCC>
+}
+
+module load <INTEL>
+
+prepend-path    C_INCLUDE_PATH     "\$MPI_PATH/include"
+prepend-path    CPLUS_INCLUDE_PATH "\$MPI_PATH/include"
+prepend-path    FPATH              "\$MPI_PATH/include"
+prepend-path    MANPATH            "\$MPI_PATH/share/man"
+
+setenv CC       mpicc
+setenv CXX      mpicxx
+setenv F90      mpifort
+setenv F77      mpifort
+setenv FC       mpifort
+
+setenv          MPI_HOME          "\$MPI_PATH"
+prepend-path    PATH              "\$MPI_PATH/bin"
+EOF
+    MODULEPATH=$MODULEPATH:${PACKAGES_DIR}_intel/modulefiles
+    module load <MPICH>_<INTEL>
+    cd "$MPI_HOME/lib"
+    for sfile in `find . -type f -name "*.la"`; do
+	if [ `grep -c 'src_temp_' $sfile` -ge 1 ]; then
+	    echo 'editing file: '$sfile
+	    perl -pi -e "s/-L.\S*src_temp_\S*[^'\s+]//g" $sfile
+	fi
+    done
+}
+##
+## End Specifics
+##############
+## The following script contains all the common functions.
+## Those functions are executed in the following order:
+
+# download
+# extract
+# pre-run
+# configure
+# make
+# make install
+# post_run
+# cleanup
+
+## pre_run and post_run are the only true specifics that are different
+## with every package
+PACKAGES_DIR="<PACKAGES_DIR>"
+RELATIVE_DIR="<RELATIVE_DIR>"
+DOWNLOAD_DIR="<DOWNLOAD_DIR>"
+TEMP_PREFIX="<TEMP_PREFIX>"
+MOOSE_JOBS=<MOOSE_JOBS>
+KEEP_FAILED=<KEEP_FAILED>
+DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
+source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/mpich-intel
+++ b/build_from_source/template/mpich-intel
@@ -14,7 +14,7 @@ ARCH=(Linux)
 # jointly supported OS's for intel compilers:
 supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
 for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
         WITH_INTEL=<WITH_INTEL>
     fi
 done

--- a/build_from_source/template/mpich-intel
+++ b/build_from_source/template/mpich-intel
@@ -11,14 +11,6 @@ BASE_DIR="<MPICH>"
 #
 ARCH=(Linux)
 
-# jointly supported OS's for intel compilers:
-supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
-for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
-        WITH_INTEL=<WITH_INTEL>
-    fi
-done
-
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
@@ -106,4 +98,5 @@ TEMP_PREFIX="<TEMP_PREFIX>"
 MOOSE_JOBS=<MOOSE_JOBS>
 KEEP_FAILED=<KEEP_FAILED>
 DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
 source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/mpich-intel
+++ b/build_from_source/template/mpich-intel
@@ -26,6 +26,9 @@ pre_run() {
     unset MODULEPATH
     source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
     module load moose/.<GCC>
+    export CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+    export CPATH=/usr/include/x86_64-linux-gnu
     export CC=icc CXX=icpc FC=ifort F77=ifort
     CONFIGURE="../configure --prefix=${PACKAGES_DIR}_intel/<MPICH>/<INTEL> --enable-shared --enable-sharedlibs=gcc --enable-fast=03 --enable-debuginfo --enable-totalview --enable-two-level-namespace CC=icc CXX=icpc FC=ifort F77=ifort F90='' CFLAGS='' CXXFLAGS='' FFLAGS='' FCFLAGS='' F90FLAGS='' F77FLAGS=''"
 }

--- a/build_from_source/template/mpich-intel
+++ b/build_from_source/template/mpich-intel
@@ -11,6 +11,14 @@ BASE_DIR="<MPICH>"
 #
 ARCH=(Linux)
 
+# jointly supported OS's for intel compilers:
+supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
+for supported_arch in ${supported_intel_archs[*]}; do
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+        WITH_INTEL=<WITH_INTEL>
+    fi
+done
+
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
@@ -30,7 +38,7 @@ pre_run() {
     export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
     export CPATH=/usr/include/x86_64-linux-gnu
     export CC=icc CXX=icpc FC=ifort F77=ifort
-    CONFIGURE="../configure --prefix=${PACKAGES_DIR}_intel/<MPICH>/<INTEL> --enable-shared --enable-sharedlibs=gcc --enable-fast=03 --enable-debuginfo --enable-totalview --enable-two-level-namespace CC=icc CXX=icpc FC=ifort F77=ifort F90='' CFLAGS='' CXXFLAGS='' FFLAGS='' FCFLAGS='' F90FLAGS='' F77FLAGS=''"
+    CONFIGURE="../configure --prefix=${PACKAGES_DIR}_intel/<MPICH>/<INTEL> --enable-shared --enable-sharedlibs=icc --enable-fast=03 --enable-debuginfo --enable-totalview --enable-two-level-namespace CC=icc CXX=icpc FC=ifort F77=ifort F90='' CFLAGS='' CXXFLAGS='' FFLAGS='' FCFLAGS='' F90FLAGS='' F77FLAGS=''"
 }
 post_run() {
     cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/<MPICH>_<INTEL>"
@@ -98,5 +106,4 @@ TEMP_PREFIX="<TEMP_PREFIX>"
 MOOSE_JOBS=<MOOSE_JOBS>
 KEEP_FAILED=<KEEP_FAILED>
 DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
-WITH_INTEL=<WITH_INTEL>
 source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -11,14 +11,6 @@ BASE_DIR="<PETSC_DEFAULT>"
 #
 ARCH=(Linux)
 
-# jointly supported OS's for intel compilers:
-supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
-for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
-        WITH_INTEL=<WITH_INTEL>
-    fi
-done
-
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -14,7 +14,7 @@ ARCH=(Linux)
 # jointly supported OS's for intel compilers:
 supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
 for supported_arch in ${supported_intel_archs[*]}; do
-    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 1 ]; then
         WITH_INTEL=<WITH_INTEL>
     fi
 done

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -1,0 +1,104 @@
+#!/bin/bash
+#############
+## Specifics
+##
+DEP=(modules cmake gcc mpich-intel)
+PACKAGE="<MPICH>_<INTEL>-opt"
+BASE_DIR="<PETSC_DEFAULT>"
+
+#####
+# Set the operating system allowed to build this module
+#
+ARCH=(Linux)
+
+#####
+# Setting any of these variables to 'false' effectively skips that step
+# This is useful for items like 'autojump' which requires a git clone/checkout
+DOWNLOAD='http://mooseframework.inl.gov/source_packages/<PETSC_DEFAULT>.tar.gz'
+EXTRACT='<PETSC_DEFAULT>.tar.gz'
+CONFIGURE="false"
+BUILD='false'
+INSTALL='false'
+
+clean_petsc() {
+    clean_attempt
+    extract
+}
+
+pre_run() {
+    if [ `uname` = "Darwin" ]; then
+        export PYTHON_BIN=python
+    else
+        export PYTHON_BIN=python2
+    fi
+    unset MODULEPATH
+    source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
+    export MODULEPATH="$MODULEPATH:${PACKAGES_DIR}_intel/modulefiles"
+    module load advanced_modules cmake <MPICH>_<INTEL>
+    CONFIGURE="$PYTHON_BIN ./configure \
+--prefix=${PACKAGES_DIR}_intel/<PETSC_DEFAULT>/<MPICH>_<INTEL>-opt \
+--download-hypre=1 \
+--with-ssl=0 \
+--with-debugging=no \
+--with-pic=1 \
+--with-shared-libraries=1 \
+--with-cc=mpicc \
+--with-cxx=mpicxx \
+--with-fc=mpif90 \
+--download-fblaslapack=1 \
+--download-metis=1 \
+--download-parmetis=1 \
+--download-superlu_dist=1 \
+--download-mumps=1 \
+--download-scalapack=1 \
+-CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
+-CFLAGS='-fPIC -fopenmp' \
+-CXXFLAGS='-fPIC -qopenmp' \
+-FFLAGS='-fPIC -qopenmp' \
+-FCFLAGS='-fPIC -qopenmp' \
+-F90FLAGS='-fPIC -qopenmp' \
+-F77FLAGS='-fPIC -qopenmp'"
+    try_command 3 "clean_petsc; configure; make MAKE_NP=$MOOSE_JOBS PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt all; make PETSC_DIR=$1/<PETSC_DEFAULT> PETSC_ARCH=arch-linux2-c-opt install"
+    CONFIGURE="false"
+}
+
+post_run() {
+    cat <<EOF > "${PACKAGES_DIR}_intel/modulefiles/<PETSC_DEFAULT>_<MPICH>_<INTEL>-opt"
+#%Module1.0#####################################################################
+##
+## <MPICH> <INTEL> <PETSC_DEFAULT> optimized superlu modulefile
+##
+##
+##
+set         BASE_PATH        "${PACKAGES_DIR}_intel"
+setenv      PETSC_DIR        "\$BASE_PATH/<PETSC_DEFAULT>/<MPICH>_<INTEL>-opt"
+module load <MPICH>_<INTEL>
+EOF
+}
+
+##
+## End Specifics
+##############
+## The following script contains all the common functions.
+## Those functions are executed in the following order:
+
+# download
+# extract
+# pre-run `pwd`
+# configure
+# make
+# make install
+# post_run `pwd`
+# cleanup
+
+## pre_run and post_run are the only true specifics that are different
+## with every package
+PACKAGES_DIR="<PACKAGES_DIR>"
+RELATIVE_DIR="<RELATIVE_DIR>"
+DOWNLOAD_DIR="<DOWNLOAD_DIR>"
+TEMP_PREFIX="<TEMP_PREFIX>"
+MOOSE_JOBS=<MOOSE_JOBS>
+KEEP_FAILED=<KEEP_FAILED>
+DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+WITH_INTEL=<WITH_INTEL>
+source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -11,6 +11,14 @@ BASE_DIR="<PETSC_DEFAULT>"
 #
 ARCH=(Linux)
 
+# jointly supported OS's for intel compilers:
+supported_intel_archs=('ubtuntu 16' 'opensuse' 'centos')
+for supported_arch in ${supported_intel_archs[*]}; do
+    if [ `lsb_release -d | grep -ic "$supported_arch"` -ge 0 ]; then
+        WITH_INTEL=<WITH_INTEL>
+    fi
+done
+
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout

--- a/common_files/linux-version_template
+++ b/common_files/linux-version_template
@@ -27,3 +27,4 @@ TRILINOS=trilinos-release-12-6-2
 DTK=2.0.0
 GITLFS=git-lfs-linux-amd64-1.4.3
 BLASLAPACK=lapack-3.7.1
+INTEL=intel-2018


### PR DESCRIPTION
Allow the package builder to build a library stack based on an Intel compiler.

  --with-intel64 (defaults to /opt/intel)
or
  --with-intel64 /root/path/to/intel

The naming convention will append '_intel' to what ever the prefix is at the time:

  --prefix /opt/moose --with-intel64

...will produce the normal GNU library stack in /opt/moose, in addition to an Intel
one located at: /opt/moose_intel. This is so we can separate the GNU stack from an
Intel one, when we go to create the moose-environment redistributable.