### PR TITLE
Better package identification

### DIFF
--- a/create_redistributable/create.py
+++ b/create_redistributable/create.py
@@ -32,7 +32,7 @@ Base class for building packages
   # Method for maintaining the package version based on package class (pkg, rpm, deb)
   def _get_build_version(self):
     with open(os.path.join(args.packages_dir, 'build'), 'r') as build_file:
-      build_date = re.findall(r'BUILD_DATE:(\d+)', build_file.read())[0]
+      build_date = re.findall(r'BUILD_DATE=(\d+)', build_file.read())[0]
     return build_date
 
   def clean_up(self):


### PR DESCRIPTION
Add machine arch to build file.
Make it easier to know what package was installed on the machine.
If we know the PR involved use that to identify the environment package version. Otherwise
use the repo hash at the time.