### PR TITLE
Fix build file being overwritten

### DIFF
--- a/create_redistributable/pkg/OSX/common_post.sh
+++ b/create_redistributable/pkg/OSX/common_post.sh
@@ -13,12 +13,4 @@ fi
 # file is created via script based on --package-dir argument
 # meaning: the intended target could be anywhere
 tar -xf /private/tmp/MOOSE_installer-tmp/payload.tar.gz -C /
-echo "<REDISTRIBUTABLE_VERSION>" > <PACKAGES_DIR>/build
 chown -R root:wheel <PACKAGES_DIR>
-
-# Remove symbolic link to openmp library if its owned by MOOSE package
-if [ -L /usr/local/lib/libomp.dylib ]; then
-  if [ `stat -f %Y /usr/local/lib/libomp.dylib | grep -c <PACKAGES_DIR>` -ge 1 ]; then
-    rm -f /usr/local/lib/libomp.dylib
-  fi
-fi


### PR DESCRIPTION
Remove the openmp library removal code. Its been years. This file should no longer exist on anyones machine.