### PR TITLE
Re-enable ptscotch for PETSc 3.9.4

### DIFF
--- a/build_from_source/template/petsc-alt-mpich-clang-dbg
+++ b/build_from_source/template/petsc-alt-mpich-clang-dbg
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-mpich-clang-opt
+++ b/build_from_source/template/petsc-alt-mpich-clang-opt
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-mpich-gcc-dbg
+++ b/build_from_source/template/petsc-alt-mpich-gcc-dbg
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-mpich-gcc-opt
+++ b/build_from_source/template/petsc-alt-mpich-gcc-opt
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-openmpi-clang-opt
+++ b/build_from_source/template/petsc-alt-openmpi-clang-opt
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-openmpi-gcc-dbg
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-dbg
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-alt-openmpi-gcc-opt
+++ b/build_from_source/template/petsc-alt-openmpi-gcc-opt
@@ -23,23 +23,6 @@ INSTALL='false'
 clean_petsc() {
     clean_attempt
     extract
-    # Fix for darwin Fortran linking issue:
-    if [ `uname` = "Darwin" ]; then
-        cat << "EOF" > petsc_darwin.patch
---- config/BuildSystem/config/libraries.py	2017-04-24 07:46:27.000000000 -0600
-+++ config/BuildSystem/config/libraries.py	2017-10-25 15:59:23.000000000 -0600
-@@ -51,7 +51,7 @@
-         flagSubst = self.language[-1].upper()+'_LINKER_SLFLAG'
-         dirname   = os.path.dirname(library).replace('\\ ',' ').replace(' ', '\\ ').replace('\\(','(').replace('(', '\\(').replace('\\)',')').replace(')', '\\)')
-         if dirname.startswith('/Applications/Xcode.app') or dirname.startswith('/Library/Developer/CommandLineTools/usr/lib'): with_rpath = None
--        if with_rpath:
-+        if False:
-           if hasattr(self.setCompilers, flagName) and not getattr(self.setCompilers, flagName) is None:
-             return [getattr(self.setCompilers, flagName)+dirname,'-L'+dirname,'-l'+name]
-           if flagSubst in self.argDB:
-EOF
-        patch -p0 < petsc_darwin.patch
-    fi
 }
 
 pre_run() {

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -47,6 +47,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -47,6 +47,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
+--download-ptscotch=1 \
 --download-fblaslapack=1 \
 --download-superlu_dist=1 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \

--- a/build_from_source/template/petsc-default-mpich-clang-dbg
+++ b/build_from_source/template/petsc-default-mpich-clang-dbg
@@ -46,6 +46,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \

--- a/build_from_source/template/petsc-default-mpich-clang-opt
+++ b/build_from_source/template/petsc-default-mpich-clang-opt
@@ -46,6 +46,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \

--- a/build_from_source/template/petsc-default-mpich-gcc-dbg
+++ b/build_from_source/template/petsc-default-mpich-gcc-dbg
@@ -47,6 +47,7 @@ pre_run() {
 --download-fblaslapack=1 \
 --download-metis=1 \
 --download-parmetis=1 \
+--download-ptscotch=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-default-mpich-gcc-opt
+++ b/build_from_source/template/petsc-default-mpich-gcc-opt
@@ -46,6 +46,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -59,6 +59,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-metis=1 \
 --download-parmetis=1 \
+--download-ptscotch=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \

--- a/build_from_source/template/petsc-default-openmpi-clang-opt
+++ b/build_from_source/template/petsc-default-openmpi-clang-opt
@@ -46,6 +46,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \

--- a/build_from_source/template/petsc-default-openmpi-gcc-opt
+++ b/build_from_source/template/petsc-default-openmpi-gcc-opt
@@ -46,6 +46,7 @@ pre_run() {
 --with-fc=mpif90 \
 --download-fblaslapack=1 \
 --download-metis=1 \
+--download-ptscotch=1 \
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-mumps=1 \


### PR DESCRIPTION
When we switched from 3.8.3 to 3.9.4 I forgot to bring along.
Remove old patching code for PETSc 3.7.6