### PR TITLE
Force conda to install PyQt=5.9.2

### DIFF
--- a/build_from_source/README.md
+++ b/build_from_source/README.md
@@ -111,4 +111,3 @@ make -j $MOOSE_JOBS
 ```
 
 If all goes well, it should be safe to to create a redistributable package. The package_builder repository contains a helper script for this process. Please see the README.md file located in package_builder/create_redistributable/.
-

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -34,7 +34,7 @@ pre_run() {
     fi
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt swig --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig --yes"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify true
 }


### PR DESCRIPTION
There is a segfault when import PyQt5, for version: 5.6.0.
Qt might also be effected. So lets install a known good combo (Qt=5.9.6)