### PR TITLE
Rolling update

### DIFF
--- a/build_from_source/template/gperftools
+++ b/build_from_source/template/gperftools
@@ -2,7 +2,8 @@
 #############
 ## Specifics
 ##
-DEP=(modules miniconda)
+DEP=(libunwind)
+PACKAGE="<GPERFTOOLS>"
 
 #####
 # Set the operating system allowed to build this module
@@ -12,31 +13,38 @@ ARCH=(Darwin Linux)
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='false'
-EXTRACT='false'
+DOWNLOAD='http://mooseframework.inl.gov/source_packages/<GPERFTOOLS>.tar.gz'
+EXTRACT='<GPERFTOOLS>.tar.gz'
 CONFIGURE='false'
-BUILD='false'
-INSTALL='false'
+BUILD='true'
+INSTALL='true'
 
 pre_run() {
     unset MODULEPATH
     source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
-    module load miniconda
-    try_command 5 "PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install boost gmp mpfr --yes"
-    rm -rf "$PACKAGES_DIR/miniconda/pkgs/"*
+    if [ `uname` = "Darwin" ]; then
+        module load advanced_modules autotools clang
+    else
+        module load advanced_modules autotools gcc
+    fi
+    CPPFLAGS="-I$PACKAGES_DIR/<LIBUNWIND>/include" CFLAGS="-I$PACKAGES_DIR/<LIBUNWIND>/include" LDFLAGS="-L$PACKAGES_DIR/<LIBUNWIND>/lib" ./configure --prefix="$PACKAGES_DIR/$PACKAGE" --enable-libunwind
 }
-
 post_run() {
-    cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/adv_modules/boost"
+    cat <<EOF >> "$PACKAGES_DIR/Modules/<MODULES>/adv_modules/gperf-tools"
 #%Module1.0#####################################################################
 ##
-## boost Module file
+## gperf-tools modulefile
 ##
 ##
 ##
-set BASE_PATH       "$PACKAGES_DIR"
-prepend-path        PATH       "\$BASE_PATH/miniconda/bin"
-setenv              BOOST_DIR  "\$BASE_PATH/miniconda"
+set          BASE_PATH         "$PACKAGES_DIR"
+prepend-path PATH              "\$BASE_PATH/$PACKAGE/bin"
+prepend-path MANPATH           "\$BASE_PATH/$PACKAGE/share/man"
+
+if { [uname sysname] != "Darwin" } {
+  prepend-path LD_LIBRARY_PATH "\$BASE_PATH/$PACKAGE/lib"
+}
+
 EOF
 }
 ##

--- a/build_from_source/template/intel-gcc
+++ b/build_from_source/template/intel-gcc
@@ -36,13 +36,13 @@ post_run() {
 ## Internal Intel <INTEL_GCC> modulefile
 ## Not to be used by itself
 ##
-set          BASE_PATH          "$PACKAGES_DIR"
+set          BASE_PATH          "${PACKAGES_DIR}_intel"
 set          INTEL_GCC_PATH     "\$BASE_PATH/<INTEL_GCC>"
 prepend-path LD_LIBRARY_PATH    "\$INTEL_GCC_PATH/lib64:\$INTEL_GCC_PATH/lib/gcc/x86_64-unknown-linux-gnu/<INTEL_GCC_VERSION>:\$INTEL_GCC_PATH/libexec/gcc/x86_64-unknown-linux-gnu/<INTEL_GCC_VERSION>"
 prepend-path PATH               "\$INTEL_GCC_PATH/bin"
 
 EOF
-    cd "$PACKAGES_DIR/<INTEL_GCC>"
+    cd "${PACKAGES_DIR}_intel/<INTEL_GCC>"
     for sfile in `find . -type f -name "*.la"`; do
         if [ `grep -c "$src_temp" $sfile` -ge 1 ]; then
             echo 'editing file: '$sfile

--- a/build_from_source/template/libtool
+++ b/build_from_source/template/libtool
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules autoconf automake)
+DEP=(modules automake)
 PACKAGE="<LIBTOOL>"
 BASE_DIR='autotools'
 

--- a/build_from_source/template/libunwind
+++ b/build_from_source/template/libunwind
@@ -2,42 +2,32 @@
 #############
 ## Specifics
 ##
-DEP=(modules miniconda)
+DEP=(gcc)
+PACKAGE="<LIBUNWIND>"
 
 #####
 # Set the operating system allowed to build this module
 #
-ARCH=(Darwin Linux)
+ARCH=(Linux)
 
 #####
 # Setting any of these variables to 'false' effectively skips that step
 # This is useful for items like 'autojump' which requires a git clone/checkout
-DOWNLOAD='false'
-EXTRACT='false'
-CONFIGURE='false'
-BUILD='false'
-INSTALL='false'
+DOWNLOAD='http://mooseframework.inl.gov/source_packages/<LIBUNWIND>.tar.gz'
+EXTRACT='<LIBUNWIND>.tar.gz'
+CONFIGURE="./configure --prefix=<PACKAGES_DIR>/$PACKAGE --enable-ptrace --enable-coredump --enable-minidebuginfo"
+BUILD='true'
+INSTALL='true'
 
 pre_run() {
     unset MODULEPATH
     source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
-    module load miniconda
-    try_command 5 "PATH=$PACKAGES_DIR/miniconda/bin:$PATH conda install boost gmp mpfr --yes"
-    rm -rf "$PACKAGES_DIR/miniconda/pkgs/"*
+    module load advanced_modules gcc
+    CC=gcc CXX=g++
 }
 
 post_run() {
-    cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/adv_modules/boost"
-#%Module1.0#####################################################################
-##
-## boost Module file
-##
-##
-##
-set BASE_PATH       "$PACKAGES_DIR"
-prepend-path        PATH       "\$BASE_PATH/miniconda/bin"
-setenv              BOOST_DIR  "\$BASE_PATH/miniconda"
-EOF
+    return
 }
 ##
 ## End Specifics
@@ -64,3 +54,4 @@ MOOSE_JOBS=<MOOSE_JOBS>
 KEEP_FAILED=<KEEP_FAILED>
 DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
 source "$RELATIVE_DIR/functions" $@
+

--- a/build_from_source/template/llvm
+++ b/build_from_source/template/llvm
@@ -258,6 +258,8 @@ post_run() {
         if [ "$?" != "0" ]; then echo "Failed to remove Entitlements from debugserver"; cleanup 1; fi
     fi
 
+    # Create link to clang-format lisp
+    cd "$PACKAGES_DIR"; ln -s "$PACKAGES_DIR/$PACKAGE/share/clang/clang-format.el" .
 }
 ##
 ## End Specifics

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -37,7 +37,7 @@ pre_run() {
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c plotly plotly-orca"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c plotly plotly-orca --yes"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
     rm -f "$PACKAGES_DIR/$PACKAGE/.condarc"
 }

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -34,7 +34,7 @@ pre_run() {
     fi
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools plotly-orca --yes"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify true
 }

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -32,6 +32,7 @@ pre_run() {
 	bash "$DOWNLOAD_DIR/<MINICONDA>-Linux-x86_64.sh" -b -p "$PACKAGES_DIR/$PACKAGE"
 	if [ $? -ne 0 ]; then echo "Failed to install $PACKAGE"; cleanup 1; fi
     fi
+
     export CONDARC="$PACKAGES_DIR/$PACKAGE/.condarc"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -34,7 +34,7 @@ pre_run() {
     fi
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools --yes"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify true
 }

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -34,9 +34,9 @@ pre_run() {
     fi
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
-    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools plotly-orca --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools --yes"
+    try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c plotly plotly-orca"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
-    PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify true
 }
 post_run() {
     cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/modulefiles/$PACKAGE"

--- a/build_from_source/template/miniconda
+++ b/build_from_source/template/miniconda
@@ -32,11 +32,13 @@ pre_run() {
 	bash "$DOWNLOAD_DIR/<MINICONDA>-Linux-x86_64.sh" -b -p "$PACKAGES_DIR/$PACKAGE"
 	if [ $? -ne 0 ]; then echo "Failed to install $PACKAGE"; cleanup 1; fi
     fi
+    export CONDARC="$PACKAGES_DIR/$PACKAGE/.condarc"
     PATH="$PACKAGES_DIR/$PACKAGE/bin:$PATH" conda config --set ssl_verify false
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda update conda --yes"
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c idaholab python=2.7 coverage reportlab mako numpy scipy scikit-learn h5py hdf5 scikit-image requests vtk=7.1.0 pyyaml matplotlib pip lxml pyflakes pandas conda-build mock yaml pyqt=5.9.2 qt=5.9.6 swig anaconda-client setuptools --yes"
     try_command 5 "PATH=$PACKAGES_DIR/$PACKAGE/bin:$PATH conda install -c plotly plotly-orca"
     sed -i -e 's/^@deprecated/#@deprecated/' "$PACKAGES_DIR/$PACKAGE/lib/python2.7/site-packages/skimage/measure/_structural_similarity.py"
+    rm -f "$PACKAGES_DIR/$PACKAGE/.condarc"
 }
 post_run() {
     cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/modulefiles/$PACKAGE"

--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -88,7 +88,7 @@ EOF
 ## <MPICH>
 ##
 module load moose/.<MPICH>_<CLANG>
-module load moose/.<PETSC_DEFAULT>_<MPICH_<CLANG>-64
+module load moose/.<PETSC_DEFAULT>_<MPICH>_<CLANG>-64
 module load moose/.<TBB>
 module load moose/.<CPPUNIT>_<CLANG>
 module load ccache

--- a/common_files/darwin-version_template
+++ b/common_files/darwin-version_template
@@ -44,3 +44,6 @@ HARFBUZZ=harfbuzz-1.3.2
 GITLFS=git-lfs-darwin-amd64-1.4.3
 VALGRIND=valgrind-3.13.0
 BLASLAPACK=lapack-3.7.1
+LIBUNWIND=libunwind-1.2
+AUTOGEN=autogen-5.18.7
+GPERFTOOLS=gperftools-2.7

--- a/common_files/linux-version_template
+++ b/common_files/linux-version_template
@@ -33,3 +33,6 @@ TRILINOS=trilinos-release-12-6-2
 DTK=2.0.0
 GITLFS=git-lfs-linux-amd64-1.4.3
 BLASLAPACK=lapack-3.7.1
+LIBUNWIND=libunwind-1.2
+AUTOGEN=autogen-5.18.7
+GPERFTOOLS=gperftools-2.7

--- a/create_redistributable/pkg/OSX/Conclusion_Panel.html
+++ b/create_redistributable/pkg/OSX/Conclusion_Panel.html
@@ -6,7 +6,7 @@
    </HEAD>
    <BODY>
       <P><FONT SIZE="+1">
-You should now close any open terminals and proceed to Step 2 on our <a href="http://mooseframework.org/getting-started/">'Getting Started'</a> pages.<br><br>
+You should now close any open terminals and proceed back to our <a href="https://mooseframework.inl.gov/getting_started/index.html">'Getting Started'</a> pages.<br><br>
 If you need assistance or would otherwise like to get social with the MOOSE community, now is a good time to join our <a href="https://groups.google.com/forum/#!forum/moose-users">mailing list</a>.
       </FONT></P>
    </BODY>

--- a/create_redistributable/pkg/OSX/cleanup_post.sh
+++ b/create_redistributable/pkg/OSX/cleanup_post.sh
@@ -1,10 +1,55 @@
 #!/bin/bash
-if [ -f """$HOME"""/.bash_profile ]; then
-        if [ `grep -c <PACKAGES_DIR>/environments/moose_profile """$HOME"""/.bash_profile` -le 0 ]; then
-		response=`osascript -e 'tell app "System Events" to display dialog "You have selected not to setup the MOOSE environment. If you choose cancel here, know that nothing will work, until you source the moose_profile script on your own. By selecting OK, the following will be appended to your ~/.bash_profile:\n\n# Uncomment to enable pretty prompt:\n# export MOOSE_PROMPT=true\n\n# Uncomment to enable autojump:\n# export MOOSE_JUMP=true\n\n# Source MOOSE profile\nif [ -f <PACKAGES_DIR>/environments/moose_profile ]; then\n\t. <PACKAGES_DIR>/environments/moose_profile\nfi"' 2>/dev/null`
-		if [ "$response" == "button returned:OK" ]; then
-			cat >> """$HOME"""/.bash_profile << EOF
+verifyItWorkes()
+{
+    for profile in "${profiles[@]}"; do
+        if [ -f """$profile""" ]; then
+            break
+        fi
+    done
+    source """$profile"""
+    if [ -z "$MOOSE_JOBS" ]; then
+        error_message="""Installer script wrote changes to\n\n\t$use_this_profile\n\nbut was unable to determine the presence of key MOOSE environment vairables in a new terminal session.\n\nBash loads the first readable profile it finds in the following order:\n\n\t~/.bash_profile\n\t~/.bash_login\n\t~/.profile\n\nYou will need to investigate these files and figure out why\n\n\t$use_this_profile\n\nis not being loaded."""
+        response=`osascript -e 'display alert "'"$error_message"'"' 2>/dev/null`
+    fi
+}
 
+function findCorrectProfile()
+{
+    # Loop through each found profile and determine the last profile being sourced
+    reverse_priority_array=()
+    for profile in "${profiles[@]}"; do
+        if [ -f """$profile""" ] && ! [ -L """$profile""" ]; then reverse_priority_array=("""$profile""" """${reverse_priority_array[@]}"""); fi
+    done
+
+    # No profile exists
+    if [ "${reverse_priority_array}x" = "x" ]; then
+        # touch """${profiles[${#profiles[@]}-1]}"""
+        reverse_priority_array=("""${profiles[${#profiles[@]}-1]}""")
+    fi
+
+    for found_profile in "${reverse_priority_array[@]}"; do
+        if [ -n "$previous_priority_profile" ]; then
+            if [ `grep -c \\\\$(basename """$previous_priority_profile""") """$found_profile"""` -ge 1 ]; then
+                use_this_profile="""$previous_priority_profile"""
+            else
+                use_this_profile="""$found_profile"""
+            fi
+        fi
+        previous_priority_profile=$found_profile
+    done
+    use_this_profile=${use_this_profile:-"""$found_profile"""}
+}
+
+function detectAndCreateProfile()
+{
+    if [ -z "$use_this_profile" ]; then
+        findCorrectProfile
+    fi
+    # First, make sure we are not already loading a MOOSE profile (perhaps they are simply updating their package)
+    if [ -f """$use_this_profile""" ] && [ "$(grep -i "environments/moose_profile" """$use_this_profile""")x" != "x" ]; then
+        return
+    fi
+    cat >> """$use_this_profile""" << EOF
 # Uncomment to enable pretty prompt:
 # export MOOSE_PROMPT=true
 
@@ -16,26 +61,29 @@ if [ -f <PACKAGES_DIR>/environments/moose_profile ]; then
         . <PACKAGES_DIR>/environments/moose_profile
 fi
 EOF
-		fi
-	fi
-else
-	response=`osascript -e 'tell app "System Events" to display dialog "You have selected not to setup the MOOSE environment. If you choose cancel here, know that nothing will work, until you source the moose_profile script on your own. By selecting OK, the following will be appended to your ~/.bash_profile:\n\n# Uncomment to enable pretty prompt:\n# export MOOSE_PROMPT=true\n\n# Uncomment to enable autojump:\n# export MOOSE_JUMP=true\n\n# Source MOOSE profile\nif [ -f <PACKAGES_DIR>/environments/moose_profile ]; then\n\t. <PACKAGES_DIR>/environments/moose_profile\nfi"' 2>/dev/null`
-	if [ "$response" == "button returned:OK" ]; then
-		cat > """$HOME"""/.bash_profile << EOF
-#!/bin/bash
-# Uncomment to enable pretty prompt:
-# export MOOSE_PROMPT=true
+}
 
-# Uncomment to enable autojump:
-# export MOOSE_JUMP=true
+function explainProfile()
+{
+    message="""You have selected not to setup the MOOSE environment. If you choose cancel here, know that nothing will work, until you source the moose_profile script on your own. By selecting OK, the following will be appended to your\n\n\t$use_this_profile\n\n# Uncomment to enable pretty prompt:\n# export 'MOOSE_PROMPT=true\n\n# Uncomment to enable autojump:\n# export MOOSE_JUMP=true\n\n# Source MOOSE profile\nif [ -f <PACKAGES_DIR>/environments/moose_profile ]; then\n\t. <PACKAGES_DIR>/environments/moose_profile\nfi"""
+    response=`osascript -e 'tell app "System Events" to display dialog "'"$message"'"' 2>/dev/null`
 
-# Source MOOSE profile
-if [ -f <PACKAGES_DIR>/environments/moose_profile ]; then
-        . <PACKAGES_DIR>/environments/moose_profile
+    if [ "$response" == "button returned:OK" ]; then
+        detectAndCreateProfile
+        verifyItWorkes
+    fi
+}
+# Bash will search and load the first readable profile it finds in the following order
+# ~/.bash_profile ~/.bash_login ~/.profile
+profiles=("""$HOME/.bash_profile""" """$HOME/.bash_login""" """$HOME/.profile""")
+
+findCorrectProfile
+if ! [ -f """$use_this_profile""" ]; then
+    explainProfile
+elif [ `grep -c environments/moose_profile """$use_this_profile"""` -le 0 ]; then
+    explainProfile
 fi
-EOF
-        chown $USER:staff """$HOME"""/.bash_profile
-	fi
-fi
+
+# Clean Up
 cd /
 rm -rf /private/tmp/MOOSE_installer-tmp

--- a/create_redistributable/pkg/OSX/environment_post.sh
+++ b/create_redistributable/pkg/OSX/environment_post.sh
@@ -1,8 +1,41 @@
 #!/bin/bash
-if [ -f $HOME/.bash_profile ]; then
-  if [ `grep -c <PACKAGES_DIR>/environments/moose_profile $HOME/.bash_profile` -le 0 ]; then
-    cat >> $HOME/.bash_profile << EOF
+function findCorrectProfile()
+{
+    # Loop through each found profile and determine the last profile being sourced
+    reverse_priority_array=()
+    for profile in "${profiles[@]}"; do
+        if [ -f """$profile""" ] && ! [ -L """$profile""" ]; then reverse_priority_array=("""$profile""" """${reverse_priority_array[@]}"""); fi
+    done
 
+    # No profile exists
+    if [ "${reverse_priority_array}x" = "x" ]; then
+        # touch """${profiles[${#profiles[@]}-1]}"""
+        reverse_priority_array=("""${profiles[${#profiles[@]}-1]}""")
+    fi
+
+    for found_profile in "${reverse_priority_array[@]}"; do
+        if [ -n "$previous_priority_profile" ]; then
+            if [ `grep -c \\\\$(basename """$previous_priority_profile""") """$found_profile"""` -ge 1 ]; then
+                use_this_profile="""$previous_priority_profile"""
+            else
+                use_this_profile="""$found_profile"""
+            fi
+        fi
+        previous_priority_profile=$found_profile
+    done
+    use_this_profile=${use_this_profile:-"""$found_profile"""}
+}
+
+function detectAndCreateProfile()
+{
+    if [ -z "$use_this_profile" ]; then
+        findCorrectProfile
+    fi
+    # First, make sure we are not already loading a MOOSE profile (perhaps they are simply updating their package)
+    if [ -f """$use_this_profile""" ] && [ "$(grep -i "environments/moose_profile" """$use_this_profile""")x" != "x" ]; then
+        return
+    fi
+    cat >> """$use_this_profile""" << EOF
 # Uncomment to enable pretty prompt:
 # export MOOSE_PROMPT=true
 
@@ -14,20 +47,9 @@ if [ -f <PACKAGES_DIR>/environments/moose_profile ]; then
         . <PACKAGES_DIR>/environments/moose_profile
 fi
 EOF
-  fi
-else
- cat > $HOME/.bash_profile << EOF
-#!/bin/bash
-# Uncomment to enable pretty prompt:
-# export MOOSE_PROMPT=true
-
-# Uncomment to enable autojump:
-# export MOOSE_JUMP=true
-
-# Source MOOSE profile
-if [ -f <PACKAGES_DIR>/environments/moose_profile ]; then
-        . <PACKAGES_DIR>/environments/moose_profile
-fi
-EOF
-        chown $USER:staff $HOME/.bash_profile
-fi
+    chown $USER:staff """$use_this_profile"""
+}
+# Bash will search and load the first readable profile it finds in the following order
+# ~/.bash_profile ~/.bash_login ~/.profile
+profiles=("""$HOME/.bash_profile""" """$HOME/.bash_login""" """$HOME/.profile""")
+detectAndCreateProfile


### PR DESCRIPTION
Adding tools necessary to build our own conda modules within the singularity containers.
This is in prep for the eventual day we support moose within conda: `conda install moose`
Exciting!

Fix Intel's gcc path
Fix link to getting started pages for OS X post-install message
Add imagemagick
Add Google Performance Tools /w dependencies required (WIP)
Add a link to clang-format lisp script
Add plotly to conda
Add better profile detection for the Darwin package installer

Refs #156 #152 #185 #184 