### PR TITLE
Remove Strumpack

### DIFF
--- a/build_from_source/template/petsc-default-64-mpich-clang
+++ b/build_from_source/template/petsc-default-64-mpich-clang
@@ -51,7 +51,6 @@ pre_run() {
 --download-parmetis=1 \
 --download-superlu_dist=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-64-mpich-gcc
+++ b/build_from_source/template/petsc-default-64-mpich-gcc
@@ -50,7 +50,6 @@ pre_run() {
 --download-ptscotch=1 \
 --download-fblaslapack=1 \
 --download-superlu_dist=1 \
---download-strumpack=1 \
 --download-scalapack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \

--- a/build_from_source/template/petsc-default-mpich-clang-dbg
+++ b/build_from_source/template/petsc-default-mpich-clang-dbg
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-mpich-clang-opt
+++ b/build_from_source/template/petsc-default-mpich-clang-opt
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-mpich-gcc-dbg
+++ b/build_from_source/template/petsc-default-mpich-gcc-dbg
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-mpich-gcc-opt
+++ b/build_from_source/template/petsc-default-mpich-gcc-opt
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-mpich-intel-opt
+++ b/build_from_source/template/petsc-default-mpich-intel-opt
@@ -63,7 +63,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 --with-blas-lapack-lib=\"$MKLROOT/lib/intel64/libmkl_intel_lp64.a $MKLROOT/lib/intel64/libmkl_sequential.a $MKLROOT/lib/intel64/libmkl_core.a\" \
 --CC=mpicc --CXX=mpicxx --FC=mpif90 --F77=mpif77 --F90=mpif90 \

--- a/build_from_source/template/petsc-default-openmpi-clang-opt
+++ b/build_from_source/template/petsc-default-openmpi-clang-opt
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \

--- a/build_from_source/template/petsc-default-openmpi-gcc-opt
+++ b/build_from_source/template/petsc-default-openmpi-gcc-opt
@@ -51,7 +51,6 @@ pre_run() {
 --download-superlu_dist=1 \
 --download-mumps=1 \
 --download-scalapack=1 \
---download-strumpack=1 \
 --with-cxx-dialect=C++11 \
 -CC=mpicc -CXX=mpicxx -FC=mpif90 -F77=mpif77 -F90=mpif90 \
 -CFLAGS='-fPIC -fopenmp' \


### PR DESCRIPTION
Strumpack is linking to system fortran libraries even while supplying
different build flags to PETSc's configure system. Therefore we can not
support strumprack in our redistributable.