### PR TITLE
Try and handle interactive non-login shells

### DIFF
--- a/create_redistributable/deb/DEBIAN/postinst
+++ b/create_redistributable/deb/DEBIAN/postinst
@@ -16,7 +16,7 @@ for a_shell in ${shells[@]}; do
             cat <<EOF > /etc/profile.d/moose-environment.${a_shell}
 # initialize moose-environment modulecmd if available
 if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
-  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -ge 1 ]; then
+  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
     ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
   else
     MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
@@ -36,7 +36,7 @@ EOF
                 cat <<EOF >> /etc/bash.bashrc
 #START-INITIALIZE-MOOSE
 if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
-  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -ge 1 ]; then
+  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
     ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
   else
     MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`

--- a/create_redistributable/deb/DEBIAN/postinst
+++ b/create_redistributable/deb/DEBIAN/postinst
@@ -16,7 +16,7 @@ for a_shell in ${shells[@]}; do
             cat <<EOF > /etc/profile.d/moose-environment.${a_shell}
 # initialize moose-environment modulecmd if available
 if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
-  if [ -n "\$MODULESHOME" ]; then
+  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -ge 1 ]; then
     ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
   else
     MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
@@ -28,6 +28,28 @@ if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
   fi
 fi
 EOF
+            if [ -f /etc/bash.bashrc ]; then
+                if [ `cat /etc/bash.bashrc | grep -c "START-INITIALIZE-MOOSE"` -ne 0 ]; then
+                    # Remove previous initialization section
+                    sed -i'' -e '/#START-INITIALIZE-MOOSE/,/#END-INITIALIZE-MOOSE/d' /etc/bash.bashrc
+                fi
+                cat <<EOF >> /etc/bash.bashrc
+#START-INITIALIZE-MOOSE
+if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
+  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -ge 1 ]; then
+    ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
+  else
+    MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
+    if [ "\${MY_SHELL}" = "bash" ]; then
+      source <PACKAGES_DIR>/Modules/3.2.10/init/bash
+    elif [ "\${MY_SHELL}" = "sh" ]; then
+      . <PACKAGES_DIR>/Modules/3.2.10/init/sh
+    fi
+  fi
+fi
+#END-INITIALIZE-MOOSE
+EOF
+            fi
         # csh and tcsh use the same profile. Do once.
         elif [ ${a_shell} = 'csh' ] || [ ${a_shell} = 'tcsh' ] && [ -d /etc/csh/login.d ] && [ -z "$DO_CSH_ONCE" ]; then
             DO_CSH_ONCE=true


### PR DESCRIPTION
Reports of folks installing our package, are not able to initialize the module system.

[edit] Seems to affect Debian systems. The RPM based machines have /etc/bashrc file, which appears to source everything in /etc/profile.d/*
