### PR TITLE
Update environment initialization/gperftools

### DIFF
--- a/build_from_source/template/golang
+++ b/build_from_source/template/golang
@@ -1,0 +1,71 @@
+#!/bin/bash
+#############
+## Specifics
+##
+DEP=(modules)
+PACKAGE="<GOLANG>"
+SERIAL=True
+
+#####
+# Set the operating system allowed to build this module
+#
+ARCH=(Darwin Linux)
+
+#####
+# Setting any of these variables to 'false' effectively skips that step
+# This is useful for items like 'autojump' which requires a git clone/checkout
+
+if [ `uname` = "Darwin" ]; then
+    SUFFIX="darwin-amd64"
+else
+    SUFFIX="linux-amd64"
+fi
+DOWNLOAD=(http://mooseframework.inl.gov/source_packages/<GOLANG>.${SUFFIX}.tar.gz)
+EXTRACT="false"
+CONFIGURE='false'
+BUILD='false'
+INSTALL='false'
+
+pre_run() {
+    cd "$1"
+    tar -xf "$DOWNLOAD_DIR/<GOLANG>.${SUFFIX}.tar.gz" -C $PACKAGES_DIR/
+    if [ "$?" != "0" ]; then echo "Failed to extract $DOWNLOAD_DIR/<GOLANG>.${SUFFIX}.tar.gz"; cleanup 1; fi
+}
+
+post_run() {
+    cat <<EOF > "$PACKAGES_DIR/Modules/<MODULES>/adv_modules/golang"
+#%Module1.0#####################################################################
+##
+## golang modulefile
+##
+##
+##
+set          BASE_PATH         "$PACKAGES_DIR"
+prepend-path PATH              "\$BASE_PATH/go/bin"
+EOF
+}
+##
+## End Specifics
+##############
+## The following script contains all the common functions.
+## Those functions are executed in the following order:
+
+# download
+# extract
+# pre-run
+# configure
+# make
+# make install
+# post_run
+# cleanup
+
+## pre_run and post_run are the only true specifics that are different
+## with every package
+PACKAGES_DIR="<PACKAGES_DIR>"
+RELATIVE_DIR="<RELATIVE_DIR>"
+DOWNLOAD_DIR="<DOWNLOAD_DIR>"
+TEMP_PREFIX="<TEMP_PREFIX>"
+MOOSE_JOBS=<MOOSE_JOBS>
+KEEP_FAILED=<KEEP_FAILED>
+DOWNLOAD_ONLY=<DOWNLOAD_ONLY>
+source "$RELATIVE_DIR/functions" $@

--- a/build_from_source/template/gperftools
+++ b/build_from_source/template/gperftools
@@ -2,7 +2,7 @@
 #############
 ## Specifics
 ##
-DEP=(modules gcc libunwind graphviz)
+DEP=(modules gcc llvm libunwind graphviz golang)
 PACKAGE="<GPERFTOOLS>"
 
 #####
@@ -23,10 +23,10 @@ pre_run() {
     unset MODULEPATH
     source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
     if [ `uname` = "Darwin" ]; then
-        module load advanced_modules autotools clang moose-tools
+        module load advanced_modules autotools clang moose-tools golang
         ./configure --prefix="$PACKAGES_DIR/$PACKAGE" --enable-libunwind
     else
-        module load advanced_modules autotools gcc moose-tools
+        module load advanced_modules autotools gcc moose-tools golang
         PATH="$PACKAGES_DIR/<LIBUNWIND>/bin:$PATH" LIBRARY_PATH="$PACKAGES_DIR/<LIBUNWIND>/lib:$LIBRARY_PATH" LD_LIBRARY_PATH="$PACKAGES_DIR/<LIBUNWIND>/lib:$LD_LIBRARY_PATH" CPATH="$PACKAGES_DIR/<LIBUNWIND>/include" CPPFLAGS="-I$PACKAGES_DIR/<LIBUNWIND>/include" CFLAGS="-I$PACKAGES_DIR/<LIBUNWIND>/include" LDFLAGS="-L$PACKAGES_DIR/<LIBUNWIND>/lib" ./configure --prefix="$PACKAGES_DIR/$PACKAGE" --enable-libunwind
     fi
 }
@@ -34,8 +34,6 @@ pre_run() {
 post_run() {
     cd "$1"
     ### Build the better pprof tool from google/pprof ###
-    if ! [ -f /usr/local/go/bin/go ]; then echo "go not installed"; cleanup 1; fi
-    export PATH=/usr/local/go/bin:$PATH
     export GOPATH="$PACKAGES_DIR/<GPERFTOOLS>"
     # Remove unwanted pprof
     mv "$GOPATH/bin/pprof" "$GOPATH/bin/original_pprof"

--- a/build_from_source/template/moose_profile
+++ b/build_from_source/template/moose_profile
@@ -28,11 +28,19 @@ post_run() {
     mkdir -p "$PACKAGES_DIR/environments"
     cat <<EOF > "$PACKAGES_DIR/environments/moose_profile"
 #!/bin/bash
-# Modules Source
-if [ -n "\$MODULEPATH" ]; then
-  export MODULEPATH="$PACKAGES_DIR/Modules/<MODULES>/modulefiles"
+### Modules Source ###
+if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
+  ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
+else
+  MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
+    if [ "\${MY_SHELL}" = "bash" ]; then
+      source <PACKAGES_DIR>/Modules/3.2.10/init/bash
+      source <PACKAGES_DIR>/Modules/3.2.10/init/bash_completion
+    elif [ "\${MY_SHELL}" = "sh" ]; then
+      . <PACKAGES_DIR>/Modules/3.2.10/init/sh
+    fi
+  fi
 fi
-source "$PACKAGES_DIR/Modules/<MODULES>/init/bash"
 
 # MOOSE_PPS_WIDTH
 export MOOSE_PPS_WIDTH=180

--- a/common_files/darwin-version_template
+++ b/common_files/darwin-version_template
@@ -47,3 +47,5 @@ BLASLAPACK=lapack-3.7.1
 LIBUNWIND=libunwind-1.3.1
 AUTOGEN=autogen-5.18.7
 GPERFTOOLS=gperftools-2.7
+GOLANG=go1.12.6
+

--- a/common_files/linux-version_template
+++ b/common_files/linux-version_template
@@ -36,3 +36,5 @@ BLASLAPACK=lapack-3.7.1
 LIBUNWIND=libunwind-1.3.1
 AUTOGEN=autogen-5.18.7
 GPERFTOOLS=gperftools-2.7
+GOLANG=go1.12.6
+

--- a/create_redistributable/deb/DEBIAN/postinst
+++ b/create_redistributable/deb/DEBIAN/postinst
@@ -16,16 +16,7 @@ for a_shell in ${shells[@]}; do
             cat <<EOF > /etc/profile.d/moose-environment.${a_shell}
 # initialize moose-environment modulecmd if available
 if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
-  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
-    ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
-  else
-    MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
-    if [ "\${MY_SHELL}" = "bash" ]; then
-      source <PACKAGES_DIR>/Modules/3.2.10/init/bash
-    elif [ "\${MY_SHELL}" = "sh" ]; then
-      . <PACKAGES_DIR>/Modules/3.2.10/init/sh
-    fi
-  fi
+  . <PACKAGES_DIR>/environments/moose_profile
 fi
 EOF
             if [ -f /etc/bash.bashrc ]; then
@@ -36,16 +27,7 @@ EOF
                 cat <<EOF >> /etc/bash.bashrc
 #START-INITIALIZE-MOOSE
 if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
-  if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
-    ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
-  else
-    MY_SHELL=\`cat /proc/\$\$/comm 2>/dev/null\`
-    if [ "\${MY_SHELL}" = "bash" ]; then
-      source <PACKAGES_DIR>/Modules/3.2.10/init/bash
-    elif [ "\${MY_SHELL}" = "sh" ]; then
-      . <PACKAGES_DIR>/Modules/3.2.10/init/sh
-    fi
-  fi
+  . <PACKAGES_DIR>/environments/moose_profile
 fi
 #END-INITIALIZE-MOOSE
 EOF
@@ -57,6 +39,8 @@ EOF
             cat <<EOF > /etc/csh/login.d/moose-environment.csh
 # initialize moose-environment modulecmd if available
 if (-d <PACKAGES_DIR>/Modules/3.2.10) then
+  setenv MOOSE_JOB \`cat /proc/cpuinfo | grep processor | wc -l\`
+  setenv MOOSE_PPS_WIDTH 180
   if (! \$?MODULEPATH ) then
     set MY_SHELL=\`cat /proc/\$\$/comm\`
     source "<PACKAGES_DIR>/Modules/3.2.10/init/\${MY_SHELL}"
@@ -74,6 +58,8 @@ EOF
 #START-INITIALIZE-MOOSE
 if [[ ( -d <PACKAGES_DIR>/Modules/3.2.10 ) ]]
 then
+  export MOOSE_JOBS=\`cat /proc/cpuinfo | grep processor | wc -l\`
+  export MOOSE_PPS_WIDTH=180
   if [[ -n \${MODULESHOME} ]]
   then
     export MODULEPATH="\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
@@ -92,6 +78,8 @@ EOF
 #START-INITIALIZE-MOOSE
 if [ "\$(cat /proc/\$\$/comm 2>/dev/null)" = "${a_shell}" ]; then
   if [ -d <PACKAGES_DIR>/Modules/3.2.10 ]; then
+    export MOOSE_JOBS=\`cat /proc/cpuinfo | grep processor | wc -l\`
+    export MOOSE_PPS_WIDTH=180
     if [ -n "\$MODULESHOME" ]; then
       ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
     else


### PR DESCRIPTION
Set MOOSE_JOBS/MOOSE_PPS_WIDTH for all shells.

When using BASH/SH, source the environments/moose_profile
to handle how the module system is initialized.

Install go-lang within the package. Use that version to build gperftools.
(this fixes package_builder failing on macihnes without go).