### PR TITLE
Fix moose_profile

### DIFF
--- a/build_from_source/template/moose_profile
+++ b/build_from_source/template/moose_profile
@@ -29,8 +29,8 @@ post_run() {
     cat <<EOF > "$PACKAGES_DIR/environments/moose_profile"
 #!/bin/bash
 ### Modules Source ###
-if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>) -le 0 ]; then
-  ${exp_cm[$index]}"\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
+if [ -n "\$MODULESHOME" ] && [ \$(echo \$MODULEPATH | grep -c <PACKAGES_DIR>/Modules) -le 0 ]; then
+  export MODULEPATH="\$MODULEPATH:<PACKAGES_DIR>/Modules/3.2.10/modulefiles"
 else
   MY_SHELL=\`ps -o comm= \$\$ | sed -e 's/-//'\`
   if [ "\${MY_SHELL}" = "bash" ]; then


### PR DESCRIPTION
While copying and pasting the sourcing code from package creation,
I accidentally included nonexistent variable declarations.