### PR TITLE
Add a warning when loading GCC directly

### DIFF
--- a/build_from_source/template/gcc
+++ b/build_from_source/template/gcc
@@ -62,6 +62,10 @@ set GCC_LIB_PATHS "\$GCC_PATH/lib64:\$GCC_PATH/lib:\$GCC_PATH/lib/gcc/${GCC_TOOL
 
 if { [uname sysname] != "Darwin" } {
   prepend-path LD_LIBRARY_PATH \$GCC_LIB_PATHS
+} else {
+  if { [is-loaded advanced_modules] && [module-info mode load] } {
+     puts stderr "Warning, the GCC compiler is not completely functional.\nFor more information, please see:\n\n\thttps://mooseframework.inl.gov/help/faq.html"
+  }
 }
 
 prepend-path PATH                        "\$GCC_PATH/bin"

--- a/build_from_source/template/module-moose-dev-gcc
+++ b/build_from_source/template/module-moose-dev-gcc
@@ -47,6 +47,9 @@ if { [ info exists ::env(MOOSE_DIR) ] } {
     prepend-path PYTHONPATH "\$MOOSE_DIR/python"
   }
 }
+if { [uname sysname] == "Darwin" && [module-info mode load] } {
+   puts stderr "Warning, the GCC compiler is not completely functional.\nFor more information, please see:\n\n\thttps://mooseframework.inl.gov/help/faq.html"
+}
 EOF
 }
 ##

--- a/build_from_source/template/module-moose-dev-gcc-alt
+++ b/build_from_source/template/module-moose-dev-gcc-alt
@@ -47,6 +47,9 @@ if { [ info exists ::env(MOOSE_DIR) ] } {
     prepend-path PYTHONPATH "\$MOOSE_DIR/python"
   }
 }
+if { [uname sysname] == "Darwin" && [module-info mode load] } {
+   puts stderr "Warning, the GCC compiler is not completely functional.\nFor more information, please see:\n\n\thttps://mooseframework.inl.gov/help/faq.html"
+}
 EOF
 }
 ##


### PR DESCRIPTION
A current issue with XCode prevents GCC from compiling libMesh.
There exists a way to hack XCode to make things work. But this
is something we will not be doing to end-users. Instead, warn
the user about the incomplete GCC compiler, and offer guidance.